### PR TITLE
Add check-file-age

### DIFF
--- a/check-file-age/README.md
+++ b/check-file-age/README.md
@@ -1,0 +1,22 @@
+# check-file-age
+
+## Description
+
+Monitor file age and size for script monitoring.
+
+## Usage
+
+```
+$ check-file-age -w 240 -W 10 -c 600 -C 0 -f filename
+```
+
+## Setting
+
+```
+[plugin.checks.fileage]
+command = "/path/to/check-file-age -f filename"
+```
+
+## Other
+
+* inspired by [check_file_age.pl](https://github.com/nagios-plugins/nagios-plugins/blob/master/plugins-scripts/check_file_age.pl)

--- a/check-file-age/check_file_age.go
+++ b/check-file-age/check_file_age.go
@@ -68,18 +68,27 @@ func main() {
 		ignoreMissing bool
 	)
 
-	flag.StringVar(&file, "f", "", "file")
-	flag.StringVar(&file, "file", "", "file")
-	flag.Int64Var(&warningAge, "w", 240, "warning age")
-	flag.Int64Var(&warningAge, "warning-age", 240, "warning age")
-	flag.Int64Var(&warningSize, "W", 0, "warning size")
-	flag.Int64Var(&warningSize, "warning-size", 0, "warning size")
-	flag.Int64Var(&criticalAge, "c", 600, "critical age")
-	flag.Int64Var(&criticalAge, "critical-age", 600, "critical age")
-	flag.Int64Var(&criticalSize, "C", 0, "critical size")
-	flag.Int64Var(&criticalSize, "critical-size", 0, "critical size")
-	flag.BoolVar(&ignoreMissing, "i", false, "ignore missing")
-	flag.BoolVar(&ignoreMissing, "ignore-missing", false, "ignore missing")
+	var (
+		fileDesc       = "monitor file name"
+		warnAgeDesc    = "warning if more old than (default: 240)"
+		warnSizeDesc   = "warning if file size less than"
+		critAgeDesc    = "critical if more old than (default: 600)"
+		critSizeDesc   = "critical if file size less than (default 0)"
+		ignoreMissDesc = "skip alert if file doesn't exist"
+	)
+
+	flag.StringVar(&file, "f", "", fileDesc+" [shorthand]")
+	flag.StringVar(&file, "file", "", fileDesc)
+	flag.Int64Var(&warningAge, "w", 240, warnAgeDesc+" [shorthand]")
+	flag.Int64Var(&warningAge, "warning-age", 240, warnAgeDesc)
+	flag.Int64Var(&warningSize, "W", 0, warnSizeDesc+" [shorthand]")
+	flag.Int64Var(&warningSize, "warning-size", 0, warnSizeDesc)
+	flag.Int64Var(&criticalAge, "c", 600, critAgeDesc+" [shorthand]")
+	flag.Int64Var(&criticalAge, "critical-age", 600, critAgeDesc)
+	flag.Int64Var(&criticalSize, "C", 0, critSizeDesc+" [shorthand]")
+	flag.Int64Var(&criticalSize, "critical-size", 0, critSizeDesc)
+	flag.BoolVar(&ignoreMissing, "i", false, ignoreMissDesc+" [shorthand]")
+	flag.BoolVar(&ignoreMissing, "ignore-missing", false, ignoreMissDesc)
 
 	flag.Parse()
 

--- a/check-file-age/check_file_age.go
+++ b/check-file-age/check_file_age.go
@@ -32,8 +32,8 @@ func (m monitor) hasWarningSize() bool {
 }
 
 func (m monitor) CheckWarning(age, size int64) bool {
-	return (m.hasWarningAge() && m.warningAge <= age) ||
-		(m.hasWarningSize() && m.warningSize <= size)
+	return (m.hasWarningAge() && m.warningAge < age) ||
+		(m.hasWarningSize() && m.warningSize > size)
 }
 
 func (m monitor) hasCriticalAge() bool {
@@ -45,8 +45,8 @@ func (m monitor) hasCriticalSize() bool {
 }
 
 func (m monitor) CheckCritical(age, size int64) bool {
-	return (m.hasCriticalAge() && m.criticalAge <= age) ||
-		(m.hasCriticalSize() && m.criticalSize <= size)
+	return (m.hasCriticalAge() && m.criticalAge < age) ||
+		(m.hasCriticalSize() && m.criticalSize > size)
 }
 
 func newMonitor(warningAge, warningSize, criticalAge, criticalSize int64) *monitor {

--- a/check-file-age/check_file_age.go
+++ b/check-file-age/check_file_age.go
@@ -90,6 +90,14 @@ func main() {
 	flag.BoolVar(&ignoreMissing, "i", false, ignoreMissDesc+" [shorthand]")
 	flag.BoolVar(&ignoreMissing, "ignore-missing", false, ignoreMissDesc)
 
+	flag.Usage = func() {
+		fmt.Fprintf(os.Stderr, "Usage:\n")
+		fmt.Fprintf(os.Stderr, "  %s [-w <secs>] [-c <secs>] [-W <size>] [-C <size>] [-i] -f <file>\n", os.Args[0])
+		fmt.Fprintf(os.Stderr, "  %s [-h | --help]\n", os.Args[0])
+		fmt.Fprintf(os.Stderr, "\n")
+		flag.PrintDefaults()
+	}
+
 	flag.Parse()
 
 	if file == "" {

--- a/check-file-age/check_file_age.go
+++ b/check-file-age/check_file_age.go
@@ -60,26 +60,39 @@ func newMonitor(warningAge, warningSize, criticalAge, criticalSize int64) *monit
 
 func main() {
 	var (
-		file          = flag.String("f", "", "file")
-		warningAge    = flag.Int64("w", 240, "warning age")
-		warningSize   = flag.Int64("W", 0, "warning size")
-		criticalAge   = flag.Int64("c", 600, "critical age")
-		criticalSize  = flag.Int64("C", 0, "critical size")
-		ignoreMissing = flag.Bool("i", false, "ignore missing")
+		file          string
+		warningAge    int64
+		warningSize   int64
+		criticalAge   int64
+		criticalSize  int64
+		ignoreMissing bool
 	)
+
+	flag.StringVar(&file, "f", "", "file")
+	flag.StringVar(&file, "file", "", "file")
+	flag.Int64Var(&warningAge, "w", 240, "warning age")
+	flag.Int64Var(&warningAge, "warning-age", 240, "warning age")
+	flag.Int64Var(&warningSize, "W", 0, "warning size")
+	flag.Int64Var(&warningSize, "warning-size", 0, "warning size")
+	flag.Int64Var(&criticalAge, "c", 600, "critical age")
+	flag.Int64Var(&criticalAge, "critical-age", 600, "critical age")
+	flag.Int64Var(&criticalSize, "C", 0, "critical size")
+	flag.Int64Var(&criticalSize, "critical-size", 0, "critical size")
+	flag.BoolVar(&ignoreMissing, "i", false, "ignore missing")
+	flag.BoolVar(&ignoreMissing, "ignore-missing", false, "ignore missing")
 
 	flag.Parse()
 
-	if *file == "" {
-		if *file = flag.Arg(0); *file == "" {
+	if file == "" {
+		if file = flag.Arg(0); file == "" {
 			fmt.Println("No file specified")
 			os.Exit(int(unknown))
 		}
 	}
 
-	stat, err := os.Stat(*file)
+	stat, err := os.Stat(file)
 	if err != nil {
-		if *ignoreMissing {
+		if ignoreMissing {
 			fmt.Println("No such file, but ignore missing is set.")
 			os.Exit(int(ok))
 		} else {
@@ -88,7 +101,7 @@ func main() {
 		}
 	}
 
-	monitor := newMonitor(*warningAge, *warningSize, *criticalAge, *criticalSize)
+	monitor := newMonitor(warningAge, warningSize, criticalAge, criticalSize)
 
 	result := ok
 
@@ -103,6 +116,6 @@ func main() {
 		result = critical
 	}
 
-	fmt.Printf("%s is %d seconds old and %d bytes.\n", *file, age, size)
+	fmt.Printf("%s is %d seconds old and %d bytes.\n", file, age, size)
 	os.Exit(int(result))
 }

--- a/check-file-age/check_file_age.go
+++ b/check-file-age/check_file_age.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"time"
+)
+
+type checkStatus int
+
+const (
+	ok checkStatus = iota
+	warning
+	critical
+	unknown
+)
+
+func main() {
+	var (
+		file          = flag.String("f", "", "file")
+		warningAge    = flag.Int64("w", 240, "warning age")
+		warningSize   = flag.Int64("W", 0, "warning size")
+		criticalAge   = flag.Int64("c", 600, "critical age")
+		criticalSize  = flag.Int64("C", 0, "critical size")
+		ignoreMissing = flag.Bool("i", false, "ignore missing")
+	)
+
+	flag.Parse()
+
+	if *file == "" {
+		if *file = flag.Arg(0); *file == "" {
+			fmt.Println("No file specified")
+			os.Exit(int(unknown))
+		}
+	}
+
+	stat, err := os.Stat(*file)
+	if err != nil {
+		if *ignoreMissing {
+			fmt.Println("No such file, but ignore missing is set.")
+			os.Exit(int(ok))
+		} else {
+			fmt.Println(err.Error())
+			os.Exit(int(unknown))
+		}
+	}
+
+	result := ok
+
+	age := time.Now().Unix() - stat.ModTime().Unix()
+	size := stat.Size()
+
+	if (*warningAge != 0 && *warningAge <= age) || (*warningSize != 0 && *warningSize <= size) {
+		result = warning
+	}
+
+	if (*criticalAge != 0 && *criticalAge <= age) || (*criticalSize != 0 && *criticalSize <= size) {
+		result = critical
+	}
+
+	fmt.Printf("%s is %d seconds old and %d bytes.\n", *file, age, size)
+	os.Exit(int(result))
+}


### PR DESCRIPTION
Hi,

This plugin checks file stat to monitor invalid file state.

For example, the file names `target` is monitored `mtime`.
* half day is over then `warning`
* 1 day is over then `critical`

```
$ check-file-age -f target -c 86400 -w 43200
```

inspired by https://github.com/nagios-plugins/nagios-plugins/blob/master/plugins-scripts/check_file_age.pl