### PR TITLE
Mysql checks

### DIFF
--- a/check-mysql-connection/README.md
+++ b/check-mysql-connection/README.md
@@ -1,0 +1,12 @@
+# check-mysql-connection
+## Description
+
+Checks the number of MySQL connections.
+
+## Setting
+
+```
+[plugin.checks.mysql-connection]
+command = "/path/to/check-mysql-connection -host=127.0.0.1 -port=3306 -username=USER -password=PASSWORD -warn=250 -crit=280
+```
+

--- a/check-mysql-connection/check-mysql-connection.go
+++ b/check-mysql-connection/check-mysql-connection.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"github.com/ziutek/mymysql/mysql"
+	_ "github.com/ziutek/mymysql/native"
+	"os"
+)
+
+// The exit status of the commands
+const (
+	OK       = 0
+	WARNING  = 1
+	CRITICAL = 2
+	UNKNOWN  = 3
+)
+
+func main() {
+	optHost := flag.String("host", "localhost", "Hostname")
+	optPort := flag.String("port", "3306", "Port")
+	optUser := flag.String("username", "root", "Username")
+	optPass := flag.String("password", "", "Password")
+	optCrit := flag.Int("crit", 250, "critical if the number of connection is over")
+	optWarn := flag.Int("warn", 200, "warning if the number of connection is over")
+	flag.Parse()
+
+	target := fmt.Sprintf("%s:%s", *optHost, *optPort)
+	db := mysql.New("tcp", "", target, *optUser, *optPass, "")
+	err := db.Connect()
+	if err != nil {
+		fmt.Println("UNKNOWN: couldn't connect DB")
+		os.Exit(UNKNOWN)
+	}
+	defer db.Close()
+
+	rows, res, err := db.Query("show global status like 'Threads_Connected'")
+	if err != nil {
+		fmt.Println("UNKNOWN: couldn't execute query")
+		os.Exit(UNKNOWN)
+	}
+
+	idxValue := res.Map("Value")
+	threadsConnected := rows[0].Int(idxValue)
+
+	if threadsConnected > *optCrit {
+		msg := fmt.Sprintf("CRITICAL: %d connections", threadsConnected)
+		fmt.Println(msg)
+		os.Exit(CRITICAL)
+	} else if threadsConnected > *optWarn {
+		msg := fmt.Sprintf("WARNING: %d connections", threadsConnected)
+		fmt.Println(msg)
+		os.Exit(WARNING)
+	}
+
+	msg := fmt.Sprintf("OK: %d connections", threadsConnected)
+	fmt.Println(msg)
+	os.Exit(OK)
+}

--- a/check-mysql-replication/README.md
+++ b/check-mysql-replication/README.md
@@ -1,0 +1,12 @@
+# check-mysql-replication
+## Description
+
+Checks MySQL replication status and its second behind master.
+
+## Setting
+
+```
+[plugin.checks.mysql-replication]
+command = "/path/to/check-mysql-replication -host=127.0.0.1 -port=3306 -username=USER -password=PASSWORD -warn=5 -crit=10
+```
+

--- a/check-mysql-replication/check-mysql-replication.go
+++ b/check-mysql-replication/check-mysql-replication.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"github.com/ziutek/mymysql/mysql"
+	_ "github.com/ziutek/mymysql/native"
+	"os"
+)
+
+// The exit status of the commands
+const (
+	OK       = 0
+	WARNING  = 1
+	CRITICAL = 2
+	UNKNOWN  = 3
+)
+
+func main() {
+	optHost := flag.String("host", "localhost", "Hostname")
+	optPort := flag.String("port", "3306", "Port")
+	optUser := flag.String("username", "root", "Username")
+	optPass := flag.String("password", "", "Password")
+	optCrit := flag.Int("crit", 1, "critical if the second behind master is over")
+	optWarn := flag.Int("warn", 1, "warning if the second behind master is over")
+	flag.Parse()
+
+	target := fmt.Sprintf("%s:%s", *optHost, *optPort)
+	db := mysql.New("tcp", "", target, *optUser, *optPass, "")
+	err := db.Connect()
+	if err != nil {
+		fmt.Println("UNKNOWN: couldn't connect DB")
+		os.Exit(UNKNOWN)
+	}
+	defer db.Close()
+
+	rows, res, err := db.Query("show slave status")
+	if err != nil {
+		fmt.Println("UNKNOWN: couldn't execute query")
+		os.Exit(UNKNOWN)
+	}
+	if len(rows) == 0 {
+		fmt.Println("OK: MySQL is not slave")
+		os.Exit(OK)
+	}
+
+	idxIoThreadRunning := res.Map("Slave_IO_Running")
+	idxSQLThreadRunning := res.Map("Slave_SQL_Running")
+	idxSecondsBehindMaster := res.Map("Seconds_Behind_Master")
+	ioThreadStatus := rows[0].Str(idxIoThreadRunning)
+	sqlThreadStatus := rows[0].Str(idxSQLThreadRunning)
+	secondsBehindMaster := rows[0].Int(idxSecondsBehindMaster)
+
+	if ioThreadStatus == "No" || sqlThreadStatus == "No" {
+		fmt.Println("CRITICAL: MySQL replication has been stopped")
+		os.Exit(CRITICAL)
+	}
+
+	if secondsBehindMaster > *optCrit {
+		msg := fmt.Sprintf("CRITICAL: MySQL replication behind master %d seconds", secondsBehindMaster)
+		fmt.Println(msg)
+		os.Exit(CRITICAL)
+	} else if secondsBehindMaster > *optWarn {
+		msg := fmt.Sprintf("WARNING: MySQL replication behind master %d seconds", secondsBehindMaster)
+		fmt.Println(msg)
+		os.Exit(WARNING)
+	}
+
+	fmt.Println("OK: MySQL replication works well")
+	os.Exit(OK)
+}


### PR DESCRIPTION
I'd like to add two plugins to official.

* check-mysql-connection
  - Checks the number of connections.
* check-mysql-replication
  - Checks the replication status and its Second Behind Master.

These plugins are from my repository.

https://github.com/hiroakis/mackerel-agent-checks-plugins
 * mackerel-check-mysql-connection
 * mackerel-check-mysql-replication

These plugins have been working on our production environment for several months.
If these are useful for people, please add.