### PR TITLE
bug check-log return int64

### DIFF
--- a/check-log/check-log.go
+++ b/check-log/check-log.go
@@ -234,7 +234,7 @@ func getBytesToSkip(f string) (int64, error) {
 	if err != nil {
 		return 0, err
 	}
-	i, err := strconv.Atoi(strings.Trim(string(b), " \r\n"))
+	i, err := strconv.ParseInt(strings.Trim(string(b), " \r\n"), 10, 64)
 	if err != nil {
 		return 0, err
 	}


### PR DESCRIPTION
strconv.Atoi return of the int32.
Changing to return to int64.

Error Message
```
/usr/local/bin/check-log --file=logfile --pattern='paten'
LOG UNKNOWN: strconv.ParseInt: parsing "2203473635": value out of range
```