### PR TITLE
Check saved skip bytes string is not ""

### DIFF
--- a/check-log/check-log.go
+++ b/check-log/check-log.go
@@ -234,7 +234,11 @@ func getBytesToSkip(f string) (int64, error) {
 	if err != nil {
 		return 0, err
 	}
-	i, err := strconv.ParseInt(strings.Trim(string(b), " \r\n"), 10, 64)
+	str := strings.Trim(string(b), " \r\n")
+	if str == "" {
+		return 0, nil
+	}
+	i, err := strconv.ParseInt(str, 10, 64)
 	if err != nil {
 		return 0, err
 	}


### PR DESCRIPTION
This pull request fixes an error caused when the file which saves the bytes to skip is accidentally empty.
```
> touch /tmp/bar; echo > /tmp/tmp/bar; check-log --pattern ERROR --file=/tmp/bar --state-dir=/tmp/
LOG UNKNOWN: strconv.ParseInt: parsing "": invalid syntax
```