### PR TITLE
check-file-age: show time in message

### DIFF
--- a/check-file-age/check_file_age.go
+++ b/check-file-age/check_file_age.go
@@ -84,7 +84,8 @@ func run(args []string) *checkers.Checker {
 
 	result := checkers.OK
 
-	age := time.Now().Unix() - stat.ModTime().Unix()
+	mtime := stat.ModTime()
+	age := time.Now().Unix() - mtime.Unix()
 	size := stat.Size()
 
 	if monitor.CheckWarning(age, size) {
@@ -95,6 +96,6 @@ func run(args []string) *checkers.Checker {
 		result = checkers.CRITICAL
 	}
 
-	msg := fmt.Sprintf("%s is %d seconds old and %d bytes.\n", opts.File, age, size)
+	msg := fmt.Sprintf("%s is %d seconds old (%02d:%02d:%02d) and %d bytes.\n", opts.File, age, mtime.Hour(), mtime.Minute(), mtime.Second(), size)
 	return checkers.NewChecker(result, msg)
 }


### PR DESCRIPTION
If mtime showed in message, I can have more piece of mind when watching host pages.

before
```
~ $ /usr/local/bin/check-file-age -f /var/log/test.log -w 240 -c 600
FileAge OK: /var/log/test.log is 0 seconds old and 62025259 bytes.
```

after
```
~ $ ./check-file-age -f /var/log/test.log -w 240 -c 600
FileAge OK: /var/log/test.log is 0 seconds old (13:52:16) and 62015637 bytes.
```