### PR TITLE
Release version 0.3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,8 +27,8 @@ deploy:
   api_key:
     secure: vmMQz+IjJ/LUa9SHAlLKyg4raSqkEBIRzqnjS1LK7ZjtcAROo6Pn0lUcC4qMZ96/VvNMdLyGndCOBXsdE2VBCY5goTI7uIW1oxbLM3qOMNQQldG1bOY34bjkiiDU15WLUsKKPEC2RdgwG1aAAsqcUDAeyRABYVBANSn9jylQnBC2b2mQMYUtVA1O9jl3Qg64Cy6MUUirE/SuKp/cnE3AakcQt54pNVsnM54bIyrbGhqThLj7p7uLJEm58oRWR7TTUSgmk/Rbj4aJSC4k5lzN9iL/Fr5AgnpEQQUg3ishE+5yqSW7f/PRqXC6ZI9p6XS7bhS8N178ImzouIsoKWltblsgUhfvE6ONyMpi1+RG+6Lp3HlpLuq0Pz/efEpcaSDg6lXDIvMBC2sA5pbPok6Yx4tJOSv8adWu9t0yGVJezYaqbN/071K9m3cM4YTQK4L39b2FxQ2ZrUhee8HZy5rDO8iqx2vgM+NXATz2L5Tjjzd4aqfIDX8R3PVImBci7se/wmamDUpOrcfSjrI2dzEQGBzBfIFIhCaCQSuEjpZqBKdcOztkn1uev7a0AAUeZ7my+uQNpAMO7/AapM7LLugmkLM06FgrHKWDPQP/T92MPyvmC04nNraetAVijVYLQnlK5+TdEMvkKHuY5afLp5mEzX+7jTSmjyaUNrbANs8bH/8=
   file:
-  - "/home/travis/rpmbuild/RPMS/noarch/mackerel-check-plugins-0.2.2-1.noarch.rpm"
-  - "/home/travis/gopath/src/github.com/mackerelio/go-check-plugins/packaging/mackerel-check-plugins_0.2.2-1_all.deb"
+  - "/home/travis/rpmbuild/RPMS/noarch/mackerel-check-plugins-0.3.0-1.noarch.rpm"
+  - "/home/travis/gopath/src/github.com/mackerelio/go-check-plugins/packaging/mackerel-check-plugins_0.3.0-1_all.deb"
   on:
     repo: mackerelio/go-check-plugins
     all_branches: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.3.0 (2016-01-06)
+
+* add check-postgresql #47 (supercaracal)
+* [check-ntpoffset] work on ntp 4.2.2 #50 (naokibtn)
+* check-file-age: show time in message #51 (naokibtn)
+* add --no-check-certificate options to check_http #52 (cl-lab-k)
+* add check-mailq, currently only available for postfix. #54 (tnmt)
+* add check-mailq and check-postgresql into package #55 (Songmu)
+
+
 ## 0.2.2 (2015-12-08)
 
 * A plugin to check ntpoffset #38 (hiroakis)

--- a/README.md
+++ b/README.md
@@ -10,8 +10,10 @@ Documentation for each plugin is located in its respective sub directory.
 * [check-http](./check-http/README.md)
 * [check-load](./check-load/README.md)
 * [check-log](./check-log/README.md)
+* [check-mailq](./check-mailq/README.md)
 * [check-mysql](./check-mysql/README.md)
 * [check-ntpoffset](./check-ntpoffset/README.md)
+* [check-postgresql](./check-postgresql/README.md)
 * [check-procs](./check-procs/README.md)
 * [check-tcp](./check-tcp/README.md)
 

--- a/packaging/deb/debian/changelog
+++ b/packaging/deb/debian/changelog
@@ -1,3 +1,20 @@
+mackerel-check-plugins (0.3.0-1) stable; urgency=low
+
+  * add check-postgresql (by supercaracal)
+    <https://github.com/mackerelio/go-check-plugins/pull/47>
+  * [check-ntpoffset] work on ntp 4.2.2 (by naokibtn)
+    <https://github.com/mackerelio/go-check-plugins/pull/50>
+  * check-file-age: show time in message (by naokibtn)
+    <https://github.com/mackerelio/go-check-plugins/pull/51>
+  * add --no-check-certificate options to check_http (by cl-lab-k)
+    <https://github.com/mackerelio/go-check-plugins/pull/52>
+  * add check-mailq, currently only available for postfix. (by tnmt)
+    <https://github.com/mackerelio/go-check-plugins/pull/54>
+  * add check-mailq and check-postgresql into package (by Songmu)
+    <https://github.com/mackerelio/go-check-plugins/pull/55>
+
+ -- Songmu <y.songmu@gmail.com>  Wed, 06 Jan 2016 20:36:21 +0900
+
 mackerel-check-plugins (0.2.2-1) stable; urgency=low
 
   * A plugin to check ntpoffset (by hiroakis)

--- a/packaging/deb/debian/rules
+++ b/packaging/deb/debian/rules
@@ -8,7 +8,7 @@ package=mackerel-check-plugins
 override_dh_auto_install:
 	dh_auto_install
 	install -d -m 755 debian/tmp/usr/local/bin
-	for i in file-age http load log ntpoffset procs tcp mysql;do \
+	for i in file-age http load log mailq ntpoffset postgresql procs tcp mysql;do \
 	    install -m755 debian/check-$$i debian/tmp/usr/local/bin; \
 	done
 

--- a/packaging/rpm/mackerel-check-plugins.spec
+++ b/packaging/rpm/mackerel-check-plugins.spec
@@ -37,6 +37,14 @@ done
 %{__targetdir}
 
 %changelog
+* Wed Jan 06 2016 <y.songmu@gmail.com> - 0.3.0
+- add check-postgresql (by supercaracal)
+- [check-ntpoffset] work on ntp 4.2.2 (by naokibtn)
+- check-file-age: show time in message (by naokibtn)
+- add --no-check-certificate options to check_http (by cl-lab-k)
+- add check-mailq, currently only available for postfix. (by tnmt)
+- add check-mailq and check-postgresql into package (by Songmu)
+
 * Tue Dec 08 2015 <y.songmu@gmail.com> - 0.2.2
 - A plugin to check ntpoffset (by hiroakis)
 - Check tcp unix domain socket (by tkuchiki)

--- a/packaging/rpm/mackerel-check-plugins.spec
+++ b/packaging/rpm/mackerel-check-plugins.spec
@@ -3,7 +3,7 @@
 %define __targetdir /usr/local/bin
 
 Name:      mackerel-check-plugins
-Version:   0.2.2
+Version:   0.3.0
 Release:   1
 License:   Commercial
 Summary:   macekrel.io check plugins
@@ -25,7 +25,7 @@ mackerel.io check plugins
 
 %{__mkdir} -p %{buildroot}%{__targetdir}
 
-for i in file-age http load log ntpoffset procs tcp mysql;do \
+for i in file-age http load log mailq ntpoffset postgresql procs tcp mysql;do \
     %{__install} -m0755 %{_sourcedir}/build/check-$i %{buildroot}%{__targetdir}/; \
 done
 


### PR DESCRIPTION
- add check-postgresql #47
- [check-ntpoffset] work on ntp 4.2.2 #50
- check-file-age: show time in message #51
- add --no-check-certificate options to check_http #52
- add check-mailq, currently only available for postfix. #54
- add check-mailq and check-postgresql into package #55