### PR TITLE
Fix duplicated help message

### DIFF
--- a/check-ntpoffset/check-ntpoffset.go
+++ b/check-ntpoffset/check-ntpoffset.go
@@ -27,7 +27,7 @@ func main() {
 func run(args []string) *checkers.Checker {
 	_, err := flags.ParseArgs(&opts, args)
 	if err != nil {
-		return checkers.Critical(err.Error())
+		os.Exit(1)
 	}
 
 	offset, err := getNtpOffset()


### PR DESCRIPTION
When `check-ntpoffset -h` run, it duplicates help messages and returns a status of 2.
Error in parsing flags is not a critical of ntpd.

before:

```console
$ /usr/local/bin/check-ntpoffset -h
Usage:
  check-ntpoffset [OPTIONS]

Application Options:
  -c, --critical= critical if the ntpoffset is over (default: 100)
  -w, --warning=  warning if the ntpoffset is over (default: 50)

Help Options:
  -h, --help      Show this help message

NTP CRITICAL: Usage:
  check-ntpoffset [OPTIONS]

Application Options:
  -c, --critical= critical if the ntpoffset is over (default: 100)
  -w, --warning=  warning if the ntpoffset is over (default: 50)

Help Options:
  -h, --help      Show this help message
```

after:

```console
$ ./check-ntpoffset -h
Usage:
  check-ntpoffset [OPTIONS]

Application Options:
  -c, --critical= critical if the ntpoffset is over (default: 100)
  -w, --warning=  warning if the ntpoffset is over (default: 50)

Help Options:
  -h, --help      Show this help message
```