### PR TITLE
check-procs: check PPID

### DIFF
--- a/check-procs/check_procs.go
+++ b/check-procs/check_procs.go
@@ -19,6 +19,7 @@ var opts struct {
 	MatchSelf     bool    `short:"m" long:"match-self" description:"Match itself"`
 	CmdPat        string  `short:"p" long:"pattern" value-name:"PATTERN" description:"Match a command against this pattern"`
 	CmdExcludePat string  `short:"x" long:"exclude-pattern" value-name:"PATTERN" description:"Don't match against a pattern to prevent false positives"`
+	Ppid          string  `long:"ppid" value-name:"PPID" description:"Check against a specific PPID"`
 	FilePid       string  `short:"f" long:"file-pid" value-name:"PID" description:"Check against a specific PID"`
 	Vsz           int64   `short:"z" long:"virtual-memory-size" value-name:"VSZ" description:"Trigger on a Virtual Memory size is bigger than this"`
 	Rss           int64   `short:"r" long:"resident-set-size" value-name:"RSS" description:"Trigger on a Resident Set size is bigger than this"`
@@ -36,6 +37,7 @@ var opts struct {
 type procState struct {
 	cmd     string
 	user    string
+	ppid    string
 	pid     string
 	vsz     int64
 	rss     int64
@@ -97,6 +99,7 @@ func matchProc(proc procState, cmdPatRegexp *regexp.Regexp, cmdExcludePatRegexp 
 	return (opts.CmdPat == "" || cmdPatRegexp.MatchString(proc.cmd)) &&
 		(opts.CmdExcludePat == "" || !cmdExcludePatRegexp.MatchString(proc.cmd)) &&
 		(opts.MatchSelf || proc.pid != strconv.Itoa(os.Getpid())) &&
+		(opts.Ppid == "" || proc.ppid == opts.Ppid) &&
 		(opts.FilePid == "" || proc.pid == opts.FilePid) &&
 		(opts.Vsz == 0 || proc.vsz <= opts.Vsz) &&
 		(opts.Rss == 0 || proc.rss <= opts.Rss) &&
@@ -148,6 +151,9 @@ func gatherMsg(count int64) string {
 	}
 	if opts.CPUOver != 0 {
 		msg += fmt.Sprintf("; csec > %d", opts.CPUOver)
+	}
+	if opts.Ppid != "" {
+		msg += fmt.Sprintf("; ppid %s", opts.Ppid)
 	}
 	if opts.FilePid != "" {
 		msg += fmt.Sprintf("; pid %s", opts.FilePid)

--- a/check-procs/check_procs_unix.go
+++ b/check-procs/check_procs_unix.go
@@ -15,9 +15,9 @@ var threadsUnknown = runtime.GOOS == "darwin"
 
 func getProcs() (proc []procState, err error) {
 	var procs []procState
-	psformat := "user,pid,vsz,rss,pcpu,nlwp,state,etime,time,command"
+	psformat := "user,ppid,pid,vsz,rss,pcpu,nlwp,state,etime,time,command"
 	if threadsUnknown {
-		psformat = "user,pid,vsz,rss,pcpu,state,etime,time,command"
+		psformat = "user,ppid,pid,vsz,rss,pcpu,state,etime,time,command"
 	}
 	output, _ := exec.Command("ps", "axwwo", psformat).Output()
 	for _, line := range strings.Split(string(output), "\n")[1:] {
@@ -32,25 +32,25 @@ func getProcs() (proc []procState, err error) {
 
 func parseProcState(line string) (proc procState, err error) {
 	fields := strings.Fields(line)
-	fieldsMinLen := 10
+	fieldsMinLen := 11
 	if threadsUnknown {
-		fieldsMinLen = 9
+		fieldsMinLen = 10
 	}
 	if len(fields) < fieldsMinLen {
 		return procState{}, errors.New("parseProcState: insufficient words")
 	}
-	vsz, _ := strconv.ParseInt(fields[2], 10, 64)
-	rss, _ := strconv.ParseInt(fields[3], 10, 64)
-	pcpu, _ := strconv.ParseFloat(fields[4], 64)
+	vsz, _ := strconv.ParseInt(fields[3], 10, 64)
+	rss, _ := strconv.ParseInt(fields[4], 10, 64)
+	pcpu, _ := strconv.ParseFloat(fields[5], 64)
 	if threadsUnknown {
-		esec := timeStrToSeconds(fields[6])
-		csec := timeStrToSeconds(fields[7])
-		return procState{strings.Join(fields[8:], " "), fields[0], fields[1], vsz, rss, pcpu, 1, fields[5], esec, csec}, nil
+		esec := timeStrToSeconds(fields[7])
+		csec := timeStrToSeconds(fields[8])
+		return procState{strings.Join(fields[9:], " "), fields[0], fields[1], fields[2], vsz, rss, pcpu, 1, fields[5], esec, csec}, nil
 	}
-	thcount, _ := strconv.ParseInt(fields[5], 10, 64)
-	esec := timeStrToSeconds(fields[7])
-	csec := timeStrToSeconds(fields[8])
-	return procState{strings.Join(fields[9:], " "), fields[0], fields[1], vsz, rss, pcpu, thcount, fields[6], esec, csec}, nil
+	thcount, _ := strconv.ParseInt(fields[6], 10, 64)
+	esec := timeStrToSeconds(fields[8])
+	csec := timeStrToSeconds(fields[9])
+	return procState{strings.Join(fields[10:], " "), fields[0], fields[1], fields[2], vsz, rss, pcpu, thcount, fields[6], esec, csec}, nil
 }
 
 func parsePerfProc(fields []string) (proc procState, err error) {

--- a/check-procs/check_procs_unix.go
+++ b/check-procs/check_procs_unix.go
@@ -53,20 +53,6 @@ func parseProcState(line string) (proc procState, err error) {
 	return procState{strings.Join(fields[10:], " "), fields[0], fields[1], fields[2], vsz, rss, pcpu, thcount, fields[6], esec, csec}, nil
 }
 
-func parsePerfProc(fields []string) (proc procState, err error) {
-	fieldsLen := 8
-	if len(fields) != fieldsLen {
-		return procState{}, errors.New("parseTaskList: insufficient words")
-	}
-	vsz, _ := strconv.ParseInt(fields[6], 10, 64) //VirtualBytes
-	rss, _ := strconv.ParseInt(fields[7], 10, 64) // WorkingSet
-	pcpu, _ := strconv.ParseFloat(fields[4], 64) // PercentProcessorTime
-	thcount, _ := strconv.ParseInt(fields[5], 10, 64) //ThreadCount
-	esec, _ := strconv.ParseInt(fields[1], 10, 64) // ElapsedTime
-	csec := int64(0)
-	return procState{fields[3] /* Name */, "", fields[2] /* IDProcess */, vsz, rss, pcpu, thcount, "", esec, csec}, nil
-}
-
 var timeRegexp = regexp.MustCompile(`(?:(\d+)-)?(?:(\d+):)?(\d+)[:.](\d+)`)
 
 func timeStrToSeconds(etime string) int64 {


### PR DESCRIPTION
I add new option for checking PPID.
It checks PPID of target processes like the following:

```console
$ ./check-procs --ppid 1 -p bash -W 0 -C 0
Procs OK: Found 0 matching processes; cmd /bash/; ppid 1
```