### PR TITLE
[tcp] Add --no-check-certificate

### DIFF
--- a/check-tcp/README.md
+++ b/check-tcp/README.md
@@ -14,21 +14,22 @@ command = "/path/to/check-tcp -H localhost -p 4224 -w 3 -c 5"
 ## Options
 
 ```
-    --service=        Service name. e.g. ftp, smtp, pop, imap and so on
--H, --hostname=       Host name or IP Address
--p, --port=           Port number
--s, --send=           String to send to the server
--e, --expect-pattern= Regexp pattern to expect in server response
--q, --quit=           String to send server to initiate a clean close of the connection
--S, --ssl             Use SSL for the connection.
--U, --unix-sock=      Unix Domain Socket
--t, --timeout=        Seconds before connection times out (default: 10)
--m, --maxbytes=       Close connection once more than this number of bytes are received
--d, --delay=          Seconds to wait between sending string and polling for response
--w, --warning=        Response time to result in warning status (seconds)
--c, --critical=       Response time to result in critical status (seconds)
--E, --escape          Can use \n, \r, \t or \ in send or quit string. Must come before send or quit option. By
-                      default, nothing added to send, \r\n added to end of quit
+    --service=             Service name. e.g. ftp, smtp, pop, imap and so on
+-H, --hostname=            Host name or IP Address
+-p, --port=                Port number
+-s, --send=                String to send to the server
+-e, --expect-pattern=      Regexp pattern to expect in server response
+-q, --quit=                String to send server to initiate a clean close of the connection
+-S, --ssl                  Use SSL for the connection.
+    --no-check-certificate Do not check certificate
+-U, --unix-sock=           Unix Domain Socket
+-t, --timeout=             Seconds before connection times out (default: 10)
+-m, --maxbytes=            Close connection once more than this number of bytes are received
+-d, --delay=               Seconds to wait between sending string and polling for response
+-w, --warning=             Response time to result in warning status (seconds)
+-c, --critical=            Response time to result in critical status (seconds)
+-E, --escape               Can use \n, \r, \t or \ in send or quit string. Must come before send or quit option. By
+                           default, nothing added to send, \r\n added to end of quit
 ```
 
 ## Other

--- a/check-tcp/check-tcp.go
+++ b/check-tcp/check-tcp.go
@@ -32,6 +32,7 @@ type exchange struct {
 	Quit          string `short:"q" long:"quit" description:"String to send server to initiate a clean close of the connection"`
 	SSL           bool   `short:"S" long:"ssl" description:"Use SSL for the connection."`
 	UnixSock      string `short:"U" long:"unix-sock" description:"Unix Domain Socket"`
+	NoCheckCertificate bool `long:"no-check-certificate" description:"Do not check certificate"`
 	expectReg     *regexp.Regexp
 }
 

--- a/check-tcp/check-tcp.go
+++ b/check-tcp/check-tcp.go
@@ -137,9 +137,11 @@ func (opts *tcpOpts) merge(ex exchange) {
 	}
 }
 
-func dial(network, address string, ssl bool) (net.Conn, error) {
+func dial(network, address string, ssl bool, no_check_certificate bool ) (net.Conn, error) {
 	if ssl {
-		return tls.Dial(network, address, &tls.Config{})
+		return tls.Dial(network, address, &tls.Config{
+			InsecureSkipVerify: no_check_certificate,
+		})
 	}
 	return net.Dial(network, address)
 }
@@ -160,9 +162,9 @@ func (opts *tcpOpts) run() *checkers.Checker {
 	}
 	var conn net.Conn
 	if opts.UnixSock != "" {
-		conn, err = dial("unix", opts.UnixSock, opts.SSL)
+		conn, err = dial("unix", opts.UnixSock, opts.SSL, opts.NoCheckCertificate)
 	} else {
-		conn, err = dial("tcp", address, opts.SSL)
+		conn, err = dial("tcp", address, opts.SSL, opts.NoCheckCertificate)
 	}
 	if err != nil {
 		return checkers.Critical(err.Error())

--- a/check-tcp/check-tcp.go
+++ b/check-tcp/check-tcp.go
@@ -138,10 +138,10 @@ func (opts *tcpOpts) merge(ex exchange) {
 	}
 }
 
-func dial(network, address string, ssl bool, no_check_certificate bool ) (net.Conn, error) {
+func dial(network, address string, ssl bool, noCheckCertificate bool ) (net.Conn, error) {
 	if ssl {
 		return tls.Dial(network, address, &tls.Config{
-			InsecureSkipVerify: no_check_certificate,
+			InsecureSkipVerify: noCheckCertificate,
 		})
 	}
 	return net.Dial(network, address)


### PR DESCRIPTION
I want to use this.
It's able to check localhost's ssl daemon. e.g.

```
check-tcp  -S -H 127.0.0.1 -p 443 -s 'GET / HTTP/1.0\r\n\r\n' -e 'nginx' --no-check-certificate -E 
```

