### PR TITLE
Fix check-tcp IPv6 testcase on OSX(?)

### DIFF
--- a/check-tcp/check-tcp_test.go
+++ b/check-tcp/check-tcp_test.go
@@ -169,13 +169,7 @@ func TestHTTPIPv6(t *testing.T) {
 		time.Sleep(time.Second / 5)
 		w.WriteHeader(200)
 		w.Header().Set("Content-Type", "text/plain")
-		conn, bufrw, err := w.(http.Hijacker).Hijack()
-		if err != nil {
-			t.Error(err)
-		}
-		defer conn.Close()
-		bufrw.WriteString("OKOK")
-		bufrw.Flush()
+		fmt.Fprint(w, "OKOK")
 	})
 
 	l, err := net.Listen("tcp", "[::1]:0")


### PR DESCRIPTION
The IPv6 test for check-tcp fails on my OS X machine for some reason. This patch fixes it, at least on my environment.

I don't know why the original code doesn't run on my OS X environment but I see no reason using Hijacker: http.HandleFunc handles everything fine.