### PR TITLE
check-redis: Report critical if master_link_status is down

### DIFF
--- a/check-redis/check-redis.go
+++ b/check-redis/check-redis.go
@@ -150,11 +150,20 @@ func checkSlave(args []string) *checkers.Checker {
 		return checkers.Unknown(err.Error())
 	}
 
-	if _, ok := (*info)["master_link_status"]; !ok {
+	if status, ok := (*info)["master_link_status"]; ok {
+		msg := fmt.Sprintf("master_link_status: %s", status)
+
+		switch status {
+		case "up":
+			return checkers.Ok(msg)
+		case "down":
+			return checkers.Critical(msg)
+		default:
+			return checkers.Unknown(msg)
+		}
+
+	} else {
+		// it may be a master!
 		return checkers.Unknown("couldn't get master_link_status")
 	}
-
-	return checkers.Ok(
-		fmt.Sprintf("master_link_status: %s", (*info)["master_link_status"]),
-	)
 }


### PR DESCRIPTION
The `check-redis slave` command reports OK even if the master link is down, in which case we would like to be notified about the disconnected link.
This patch makes the command to report Critical if the link is down.