### PR TITLE
check-redis: Fixed panic

### DIFF
--- a/check-redis/check-redis.go
+++ b/check-redis/check-redis.go
@@ -120,10 +120,10 @@ func checkReachable(args []string) *checkers.Checker {
 	}
 
 	c, info, err := connectRedisGetInfo(opts)
-	defer c.Close()
 	if err != nil {
 		return checkers.Unknown(err.Error())
 	}
+	defer c.Close()
 
 	if _, ok := (*info)["redis_version"]; !ok {
 		return checkers.Unknown("couldn't get redis_version")
@@ -145,10 +145,10 @@ func checkSlave(args []string) *checkers.Checker {
 	}
 
 	c, info, err := connectRedisGetInfo(opts)
-	defer c.Close()
 	if err != nil {
 		return checkers.Unknown(err.Error())
 	}
+	defer c.Close()
 
 	if _, ok := (*info)["master_link_status"]; !ok {
 		return checkers.Unknown("couldn't get master_link_status")


### PR DESCRIPTION
To avoid `panic: runtime error: invalid memory address or nil pointer dereference`
This is happeded when the defer tried closing nil redis.Client.

I tested both master binary and pr-branch binary.

```
/m/d/g/g/check-redis ❯❯❯ ps aux | grep redis-server
great           45931   0.0  0.0  2461800    468 s004  S+   水06PM   1:16.09 redis-server 127.0.0.1:6380
great            5145   0.0  0.0  3060960    644 s040  S+   19 216    2:42.71 redis-server *:6379
great           17361   0.0  0.0  2434820    684 s055  S+   11:53AM   0:00.00 grep --color redis-server
```

```
# master binary
/m/d/g/g/check-redis ❯❯❯ ./check-redis reachable --host=localhost --port=6379
Redis Reachable OK: version: 3.0.6
/m/d/g/g/check-redis ❯❯❯ ./check-redis reachable --host=localhost --port=6380
Redis Reachable OK: version: 3.0.6

/m/d/g/g/check-redis ❯❯❯ ./check-redis reachable --host=localhost --port=6381
panic: runtime error: invalid memory address or nil pointer dereference
[signal 0xb code=0x1 addr=0x0 pc=0xa545e]

goroutine 1 [running]:
github.com/fzzy/radix/redis.(*Client).Close(0x0, 0x0, 0x0)
        /Users/great/.go/src/github.com/fzzy/radix/redis/client.go:68 +0x5e
main.checkReachable(0xc820076160, 0x2, 0x2, 0xc820018240)
        /mtburn/dev/go/go-check-plugins/check-redis/check-redis.go:125 +0x2f1
main.main()
        /mtburn/dev/go/go-check-plugins/check-redis/check-redis.go:48 +0x4d8

goroutine 17 [syscall, locked to thread]:
runtime.goexit()
        /usr/local/Cellar/go/1.5.3/libexec/src/runtime/asm_amd64.s:1721 +0x1
```

```
# pr-branch binary
/m/d/g/g/check-redis ❯❯❯ go build
/m/d/g/g/check-redis ❯❯❯ ./check-redis reachable --host=localhost --port=6381
Redis Reachable UNKNOWN: couldn't connect: dial tcp [::1]:6381: getsockopt: connection refused
/m/d/g/g/check-redis ❯❯❯ ./check-redis slave --host=localhost --port=6381
Redis Slave UNKNOWN: couldn't connect: dial tcp [::1]:6381: getsockopt: connection refused
```