### PR TITLE
check-procs: Fixed the counting logic with -p

### DIFF
--- a/check-procs/check_procs.go
+++ b/check-procs/check_procs.go
@@ -17,6 +17,7 @@ var opts struct {
 	WarnUnder     int64   `short:"W" long:"warn-under" value-name:"N" default:"1" description:"Trigger a warning if under a number"`
 	CritUnder     int64   `short:"C" long:"critical-under" value-name:"N" default:"1" description:"Trigger a critial if under a number"`
 	MatchSelf     bool    `short:"m" long:"match-self" description:"Match itself"`
+	MatchParent   bool    `short:"M" long:"match-parent" description:"Match parent"`
 	CmdPat        string  `short:"p" long:"pattern" value-name:"PATTERN" description:"Match a command against this pattern"`
 	CmdExcludePat string  `short:"x" long:"exclude-pattern" value-name:"PATTERN" description:"Don't match against a pattern to prevent false positives"`
 	Ppid          string  `long:"ppid" value-name:"PPID" description:"Check against a specific PPID"`
@@ -99,6 +100,7 @@ func matchProc(proc procState, cmdPatRegexp *regexp.Regexp, cmdExcludePatRegexp 
 	return (opts.CmdPat == "" || cmdPatRegexp.MatchString(proc.cmd)) &&
 		(opts.CmdExcludePat == "" || !cmdExcludePatRegexp.MatchString(proc.cmd)) &&
 		(opts.MatchSelf || proc.pid != strconv.Itoa(os.Getpid())) &&
+		(opts.MatchParent || proc.pid != strconv.Itoa(os.Getppid())) &&
 		(opts.Ppid == "" || proc.ppid == opts.Ppid) &&
 		(opts.FilePid == "" || proc.pid == opts.FilePid) &&
 		(opts.Vsz == 0 || proc.vsz <= opts.Vsz) &&


### PR DESCRIPTION
`check-procs -p xxx` invoked by mackerel-agent output `Found 1 matching processes` when no xxx process exists .

mackerel-agent invokes a check command using `/bin/sh -c ""`, which for example creates a process tree like below.

```
great@ip-10-0-1-176:~$ /bin/sh -c "ps axfwwo user,ppid,pid,vsz,rss,pcpu,nlwp,state,etime,time,command"
USER      PPID   PID    VSZ   RSS %CPU NLWP S     ELAPSED     TIME COMMAND
great    30523 30524  22392  3884  0.0    1 S       01:48 00:00:00          \_ -bash
great    30524 30615   4440   652  0.0    1 S       00:00 00:00:00              \_ /bin/sh -c ps axfwwo user,ppid,pid,vsz,rss,pcpu,nlwp,state,etime,time,command
great    30615 30616  18276  1428  0.0    1 R       00:00 00:00:00                  \_ ps axfwwo user,ppid,pid,vsz,rss,pcpu,nlwp,state,etime,time,command
```

I tested both master binary and pr-branch binary. I did not run supervisord.

```
# edit in mackerel-agent.conf
[plugin.checks.procs]
command = "/home/mtburn/dev/go-check-plugins/check-procs/check-procs -p supervisord"
```

```
# master binary
2016/02/28 16:58:04 checker.go:80: DEBUG <checks> Checker "procs" status=OK message="Procs OK: Found 1 matching processes; cmd /supervisord/\n"
2016/02/28 16:58:04 command.go:347: DEBUG <command> checker "procs": report=&{procs OK Procs OK: Found 1 matching processes; cmd /supervisord/
 2016-02-28 16:58:04.732629048 +0900 JST <nil> <nil>}
```

```
# pr-branch binary
2016/02/28 17:06:35 checker.go:80: DEBUG <checks> Checker "procs" status=CRITICAL message="Procs CRITICAL: Found 0 matching processes; cmd /supervisord/\n"
2016/02/28 17:06:35 command.go:347: DEBUG <command> checker "procs": report=&{procs CRITICAL Procs CRITICAL: Found 0 matching processes; cmd /supervisord/
 2016-02-28 17:06:35.82266648 +0900 JST <nil> <nil>}
```

At least for our product, we expect to count only the process which is no relation with check plugin command.
Like ex. `ps aux | grep supervisord` output `grep supervisord`, but we want to exclude this line.