### PR TITLE
Release version 0.5.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,8 +26,8 @@ deploy:
   api_key:
     secure: vmMQz+IjJ/LUa9SHAlLKyg4raSqkEBIRzqnjS1LK7ZjtcAROo6Pn0lUcC4qMZ96/VvNMdLyGndCOBXsdE2VBCY5goTI7uIW1oxbLM3qOMNQQldG1bOY34bjkiiDU15WLUsKKPEC2RdgwG1aAAsqcUDAeyRABYVBANSn9jylQnBC2b2mQMYUtVA1O9jl3Qg64Cy6MUUirE/SuKp/cnE3AakcQt54pNVsnM54bIyrbGhqThLj7p7uLJEm58oRWR7TTUSgmk/Rbj4aJSC4k5lzN9iL/Fr5AgnpEQQUg3ishE+5yqSW7f/PRqXC6ZI9p6XS7bhS8N178ImzouIsoKWltblsgUhfvE6ONyMpi1+RG+6Lp3HlpLuq0Pz/efEpcaSDg6lXDIvMBC2sA5pbPok6Yx4tJOSv8adWu9t0yGVJezYaqbN/071K9m3cM4YTQK4L39b2FxQ2ZrUhee8HZy5rDO8iqx2vgM+NXATz2L5Tjjzd4aqfIDX8R3PVImBci7se/wmamDUpOrcfSjrI2dzEQGBzBfIFIhCaCQSuEjpZqBKdcOztkn1uev7a0AAUeZ7my+uQNpAMO7/AapM7LLugmkLM06FgrHKWDPQP/T92MPyvmC04nNraetAVijVYLQnlK5+TdEMvkKHuY5afLp5mEzX+7jTSmjyaUNrbANs8bH/8=
   file:
-  - "/home/travis/rpmbuild/RPMS/noarch/mackerel-check-plugins-0.4.0-1.noarch.rpm"
-  - "/home/travis/gopath/src/github.com/mackerelio/go-check-plugins/packaging/mackerel-check-plugins_0.4.0-1_all.deb"
+  - "/home/travis/rpmbuild/RPMS/noarch/mackerel-check-plugins-0.5.0-1.noarch.rpm"
+  - "/home/travis/gopath/src/github.com/mackerelio/go-check-plugins/packaging/mackerel-check-plugins_0.5.0-1_all.deb"
   on:
     repo: mackerelio/go-check-plugins
     all_branches: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## 0.5.0 (2016-03-02)
+
+* add check-solr #46 (supercaracal)
+*  add check-jmx-jolokia #68 (y-kuno)
+* check-memcached #69 (naokibtn)
+* Add scheme option to check-elasticsearch #70 (yano3)
+* Check file size #72 (hiroakis)
+* Add uptime sub command to check-mysql #73 (kazeburo)
+* add check-cert-file #74 (kazeburo)
+* [tcp] Add --no-check-certificate #75 (kazeburo)
+* Fixed slurp. conn.read returns content with EOF #76 (kazeburo)
+* Fix check-tcp IPv6 testcase on OSX(?) #77 (hanazuki)
+* check-redis: Report critical if master_link_status is down #79 (hanazuki)
+* check-redis: Fixed panic #80 (yoheimuta)
+* check-procs: Fixed the counting logic with -p #81 (yoheimuta)
+* add check-uptime #82 (Songmu)
+
+
 ## 0.4.0 (2016-02-04)
 
 * Fix duplicated help message #58 (hfm)

--- a/README.md
+++ b/README.md
@@ -6,19 +6,24 @@ Check Plugins for monitoring written in golang.
 
 Documentation for each plugin is located in its respective sub directory.
 
+* [check-cert-file](./check-cert-file/README.md)
 * [check-elasticsearch](./check-elasticsearch/README.md)
 * [check-file-age](./check-file-age/README.md)
 * [check-file-size](./check-file-size/README.md)
 * [check-http](./check-http/README.md)
+* [check-jmx-jolokia](./check-jmx-jolokia/README.md)
 * [check-load](./check-load/README.md)
 * [check-log](./check-log/README.md)
 * [check-mailq](./check-mailq/README.md)
+* [check-memcached](./check-memcached/README.md)
 * [check-mysql](./check-mysql/README.md)
 * [check-ntpoffset](./check-ntpoffset/README.md)
 * [check-postgresql](./check-postgresql/README.md)
 * [check-procs](./check-procs/README.md)
 * [check-redis](./check-redis/README.md)
+* [check-solr](./check-solr/README.md)
 * [check-tcp](./check-tcp/README.md)
+* [check-uptime](./check-uptime/README.md)
 
 Specification
 -------------

--- a/packaging/deb/debian/changelog
+++ b/packaging/deb/debian/changelog
@@ -1,3 +1,36 @@
+mackerel-check-plugins (0.5.0-1) stable; urgency=low
+
+  * add check-solr (by supercaracal)
+    <https://github.com/mackerelio/go-check-plugins/pull/46>
+  *  add check-jmx-jolokia (by y-kuno)
+    <https://github.com/mackerelio/go-check-plugins/pull/68>
+  * check-memcached (by naokibtn)
+    <https://github.com/mackerelio/go-check-plugins/pull/69>
+  * Add scheme option to check-elasticsearch (by yano3)
+    <https://github.com/mackerelio/go-check-plugins/pull/70>
+  * Check file size (by hiroakis)
+    <https://github.com/mackerelio/go-check-plugins/pull/72>
+  * Add uptime sub command to check-mysql (by kazeburo)
+    <https://github.com/mackerelio/go-check-plugins/pull/73>
+  * add check-cert-file (by kazeburo)
+    <https://github.com/mackerelio/go-check-plugins/pull/74>
+  * [tcp] Add --no-check-certificate (by kazeburo)
+    <https://github.com/mackerelio/go-check-plugins/pull/75>
+  * Fixed slurp. conn.read returns content with EOF (by kazeburo)
+    <https://github.com/mackerelio/go-check-plugins/pull/76>
+  * Fix check-tcp IPv6 testcase on OSX(?) (by hanazuki)
+    <https://github.com/mackerelio/go-check-plugins/pull/77>
+  * check-redis: Report critical if master_link_status is down (by hanazuki)
+    <https://github.com/mackerelio/go-check-plugins/pull/79>
+  * check-redis: Fixed panic (by yoheimuta)
+    <https://github.com/mackerelio/go-check-plugins/pull/80>
+  * check-procs: Fixed the counting logic with -p (by yoheimuta)
+    <https://github.com/mackerelio/go-check-plugins/pull/81>
+  * add check-uptime (by Songmu)
+    <https://github.com/mackerelio/go-check-plugins/pull/82>
+
+ -- Songmu <y.songmu@gmail.com>  Wed, 02 Mar 2016 15:17:38 +0900
+
 mackerel-check-plugins (0.4.0-1) stable; urgency=low
 
   * Fix duplicated help message (by hfm)

--- a/packaging/rpm/mackerel-check-plugins.spec
+++ b/packaging/rpm/mackerel-check-plugins.spec
@@ -3,7 +3,7 @@
 %define __targetdir /usr/local/bin
 
 Name:      mackerel-check-plugins
-Version:   0.4.0
+Version:   0.5.0
 Release:   1
 License:   Commercial
 Summary:   macekrel.io check plugins

--- a/packaging/rpm/mackerel-check-plugins.spec
+++ b/packaging/rpm/mackerel-check-plugins.spec
@@ -37,6 +37,22 @@ done
 %{__targetdir}
 
 %changelog
+* Wed Mar 02 2016 <y.songmu@gmail.com> - 0.5.0
+- add check-solr (by supercaracal)
+-  add check-jmx-jolokia (by y-kuno)
+- check-memcached (by naokibtn)
+- Add scheme option to check-elasticsearch (by yano3)
+- Check file size (by hiroakis)
+- Add uptime sub command to check-mysql (by kazeburo)
+- add check-cert-file (by kazeburo)
+- [tcp] Add --no-check-certificate (by kazeburo)
+- Fixed slurp. conn.read returns content with EOF (by kazeburo)
+- Fix check-tcp IPv6 testcase on OSX(?) (by hanazuki)
+- check-redis: Report critical if master_link_status is down (by hanazuki)
+- check-redis: Fixed panic (by yoheimuta)
+- check-procs: Fixed the counting logic with -p (by yoheimuta)
+- add check-uptime (by Songmu)
+
 * Thu Feb 04 2016 <y.songmu@gmail.com> - 0.4.0
 - Fix duplicated help message (by hfm)
 - add qmail queue check to check-mailq (by tnmt)


### PR DESCRIPTION
- add check-solr #46
-  add check-jmx-jolokia #68
- check-memcached #69
- Add scheme option to check-elasticsearch #70
- Check file size #72
- Add uptime sub command to check-mysql #73
- add check-cert-file #74
- [tcp] Add --no-check-certificate #75
- Fixed slurp. conn.read returns content with EOF #76
- Fix check-tcp IPv6 testcase on OSX(?) #77
- check-redis: Report critical if master_link_status is down #79
- check-redis: Fixed panic #80
- check-procs: Fixed the counting logic with -p #81
- add check-uptime #82