### PR TITLE
Fix setting example of check-uptime README

### DIFF
--- a/check-uptime/README.md
+++ b/check-uptime/README.md
@@ -8,7 +8,7 @@ Check uptime seconds.
 
 ```
 [plugin.checks.uptime]
-command = "/path/to/check-uptime --warning-under=600 --critical-under=120"
+command = "/path/to/check-uptime --warn-under=600 --critical-under=120"
 ```
 
 ## Options


### PR DESCRIPTION
About options for warning threshold, written in `Setting` use `--warning-under=600`, but it seems correct to use `--warn-under=600` seemingly.
(Other plugins are used `--warn-under`, too.) 