### PR TITLE
Use `--warning-*` instead of `--warn-*` 

### DIFF
--- a/check-uptime/README.md
+++ b/check-uptime/README.md
@@ -14,8 +14,8 @@ command = "/path/to/check-uptime --warning-under=600 --critical-under=120"
 ## Options
 
 ```
-  -w, --warn-under=N        Trigger a warning if under the seconds
+  -w, --warning-under=N     Trigger a warning if under the seconds
   -c, --critical-under=N    Trigger a critial if under the seconds
-  -W, --warn-over=N         Trigger a warning if over the seconds
+  -W, --warning-over=N      Trigger a warning if over the seconds
   -C, --critical-over=N     Trigger a critical if over the seconds
 ```

--- a/check-uptime/check-uptime.go
+++ b/check-uptime/check-uptime.go
@@ -11,9 +11,9 @@ import (
 )
 
 var opts struct {
-	WarnUnder *float64 `short:"w" long:"warn-under" value-name:"N" description:"Trigger a warning if under the seconds"`
+	WarnUnder *float64 `short:"w" long:"warning-under" value-name:"N" description:"Trigger a warning if under the seconds"`
 	CritUnder *float64 `short:"c" long:"critical-under" value-name:"N" description:"Trigger a critial if under the seconds"`
-	WarnOver  *float64 `short:"W" long:"warn-over" value-name:"N" description:"Trigger a warning if over the seconds"`
+	WarnOver  *float64 `short:"W" long:"warning-over" value-name:"N" description:"Trigger a warning if over the seconds"`
 	CritOver  *float64 `short:"C" long:"critical-over" value-name:"N" description:"Trigger a critical if over the seconds"`
 }
 


### PR DESCRIPTION
relate with https://github.com/mackerelio/go-check-plugins/pull/87#issuecomment-197206911

@Songmu intend to use `--warning-under` `--warning-over`, but implementation is not.
This is the pull request to amend that implementation.