### PR TITLE
added check-masterha command to check masterha status

### DIFF
--- a/check-masterha/README.md
+++ b/check-masterha/README.md
@@ -1,0 +1,29 @@
+# check-masterha
+
+## Description
+
+Monitor MasterHA status.
+
+## Usage
+
+```
+$ check-masterha --conf /path/to/masterha
+
+```
+
+## Setting
+
+```
+[plugin.checks.masterha-status]
+command = "/path/to/check-masterha status --all"
+
+[plugin.checks.masterha-repl]
+command = "/path/to/check-masterha repl --conf /path/to/masterha_cluster.cnf"
+
+[plugin.checks.masterha-ssh]
+command = "/path/to/check-masterha ssh --conf /path/to/masterha_cluster.cnf"
+```
+
+## Other
+
+* [Master HA Manager](https://code.google.com/p/mysql-master-ha/)

--- a/check-masterha/check_masterha.go
+++ b/check-masterha/check_masterha.go
@@ -26,9 +26,9 @@ type options struct {
 }
 
 type executer interface {
-	makeCommandName() string
-	makeCommandArgs() []string
-	parse(string) (checkers.Status, string)
+	MakeCommandName() string
+	MakeCommandArgs() []string
+	Parse(string) (checkers.Status, string)
 }
 
 type subcommand struct {
@@ -59,18 +59,18 @@ func (c subcommand) ConfigFiles() ([]string, error) {
 	return configFiles, nil
 }
 
-func (c subcommand) makeCommandName() string {
-	return c.Executer.makeCommandName()
+func (c subcommand) MakeCommandName() string {
+	return c.Executer.MakeCommandName()
 }
 
-func (c subcommand) makeCommandArgs() []string {
-	args := c.Executer.makeCommandArgs()
+func (c subcommand) MakeCommandArgs() []string {
+	args := c.Executer.MakeCommandArgs()
 	args = append(args, "--conf", c.Config)
 	return args
 }
 
-func (c subcommand) parse(result string) (checkers.Status, string) {
-	return c.Executer.parse(result)
+func (c subcommand) Parse(result string) (checkers.Status, string) {
+	return c.Executer.Parse(result)
 }
 
 func (c subcommand) executeAll() (*checkers.Checker, error) {
@@ -100,8 +100,8 @@ func (c subcommand) executeAll() (*checkers.Checker, error) {
 
 func (c subcommand) execute(config string) (*checkers.Checker, error) {
 	c.Config = config
-	name := c.makeCommandName()
-	args := c.makeCommandArgs()
+	name := c.MakeCommandName()
+	args := c.MakeCommandArgs()
 
 	cmd := exec.Command(name, args...)
 
@@ -117,7 +117,7 @@ func (c subcommand) execute(config string) (*checkers.Checker, error) {
 		return nil, err
 	}
 
-	result, msg := c.parse(buf.String())
+	result, msg := c.Parse(buf.String())
 	if failure && result == checkers.UNKNOWN {
 		result = checkers.WARNING
 	}

--- a/check-masterha/check_masterha.go
+++ b/check-masterha/check_masterha.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/jessevdk/go-flags"
+	"github.com/mackerelio/checkers"
+)
+
+func main() {
+	var opts options
+	parser := flags.NewParser(&opts, flags.Default)
+	if _, err := parser.Parse(); err != nil {
+		os.Exit(1)
+	}
+}
+
+type options struct {
+	Status statusChecker `command:"status" description:"check to masterha_check_status"`
+	Repl   replChecker   `command:"repl"   description:"check to masterha_check_repl"`
+	SSH    sshChecker    `command:"ssh"    description:"check to masterha_check_ssh"`
+}
+
+type subcommand interface {
+	makeCommandName() string
+	makeCommandArgs() []string
+	parse(string) (checkers.Status, string)
+}
+
+func executeSubcommand(c subcommand) (*checkers.Checker, error) {
+	name := c.makeCommandName()
+	args := c.makeCommandArgs()
+
+	cmd := exec.Command(name, args...)
+
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+
+	var failure bool
+	err := cmd.Run()
+	if _, ok := err.(*exec.ExitError); ok {
+		failure = true
+	} else if err != nil {
+		return nil, err
+	}
+
+	result, msg := c.parse(buf.String())
+	if failure && result == checkers.UNKNOWN {
+		result = checkers.WARNING
+	}
+	checker := checkers.NewChecker(result, msg)
+	return checker, nil
+}
+
+func extractNonEmptyLines(lines []string) []string {
+	result := make([]string, 0, len(lines))
+	for _, line := range lines {
+		if line != "" {
+			result = append(result, line)
+		}
+	}
+	return result
+}
+
+func extractErrorMsg(msg string) string {
+	var errors []string
+	for _, line := range strings.Split(msg, "\n") {
+		if strings.Contains(line, "[error]") {
+			errors = append(errors, line)
+		}
+	}
+
+	if len(errors) == 0 {
+		return msg
+	}
+
+	return strings.Join(errors, "\n")
+}

--- a/check-masterha/check_masterha_repl.go
+++ b/check-masterha/check_masterha_repl.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"strings"
+
+	"github.com/mackerelio/checkers"
+)
+
+type replChecker struct {
+	Config string `short:"c" long:"conf" required:"true" description:"target config file"`
+}
+
+func (c replChecker) Execute(args []string) error {
+	checker, err := executeSubcommand(c)
+	if err != nil {
+		return err
+	}
+	checker.Name = "MasterHA"
+	checker.Exit()
+	return nil
+}
+
+func (c replChecker) makeCommandName() string {
+	return "masterha_check_repl"
+}
+
+func (c replChecker) makeCommandArgs() []string {
+	args := [2]string{"--conf", c.Config}
+	return args[:]
+}
+
+func (c replChecker) parse(out string) (checkers.Status, string) {
+	lines := extractNonEmptyLines(strings.Split(out, "\n"))
+	lastLine := lines[len(lines)-1]
+	if strings.Contains(lastLine, "MySQL Replication Health is OK.") {
+		return checkers.OK, lastLine
+	} else if strings.Contains(lastLine, "MySQL Replication Health is NOT OK!") {
+		return checkers.CRITICAL, lastLine
+	} else {
+		msg := extractErrorMsg(out)
+		return checkers.UNKNOWN, msg
+	}
+}

--- a/check-masterha/check_masterha_repl.go
+++ b/check-masterha/check_masterha_repl.go
@@ -7,14 +7,17 @@ import (
 )
 
 type replChecker struct {
-	Config string `short:"c" long:"conf" required:"true" description:"target config file"`
+	subcommand
 }
 
 func (c replChecker) Execute(args []string) error {
-	checker, err := executeSubcommand(c)
+	c.Executer = &c
+
+	checker, err := c.executeAll()
 	if err != nil {
 		return err
 	}
+
 	checker.Name = "MasterHA"
 	checker.Exit()
 	return nil
@@ -25,8 +28,7 @@ func (c replChecker) makeCommandName() string {
 }
 
 func (c replChecker) makeCommandArgs() []string {
-	args := [2]string{"--conf", c.Config}
-	return args[:]
+	return make([]string, 0, 2)
 }
 
 func (c replChecker) parse(out string) (checkers.Status, string) {

--- a/check-masterha/check_masterha_repl.go
+++ b/check-masterha/check_masterha_repl.go
@@ -25,11 +25,11 @@ func (c replChecker) Execute(args []string) error {
 	return nil
 }
 
-func (c replChecker) makeCommandName() string {
+func (c replChecker) MakeCommandName() string {
 	return "masterha_check_repl"
 }
 
-func (c replChecker) makeCommandArgs() []string {
+func (c replChecker) MakeCommandArgs() []string {
 	args := make([]string, 0, c.ArgsLength())
 	if c.SecondsBehindMaster > 0 {
 		secondsBehindMaster := strconv.Itoa(c.SecondsBehindMaster)
@@ -45,7 +45,7 @@ func (c replChecker) ArgsLength() int {
 	return 2
 }
 
-func (c replChecker) parse(out string) (checkers.Status, string) {
+func (c replChecker) Parse(out string) (checkers.Status, string) {
 	lines := extractNonEmptyLines(strings.Split(out, "\n"))
 	lastLine := lines[len(lines)-1]
 	if strings.Contains(lastLine, "MySQL Replication Health is OK.") {

--- a/check-masterha/check_masterha_repl.go
+++ b/check-masterha/check_masterha_repl.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"strconv"
 	"strings"
 
 	"github.com/mackerelio/checkers"
@@ -8,6 +9,7 @@ import (
 
 type replChecker struct {
 	subcommand
+	SecondsBehindMaster int `long:"seconds_behind_master" description:"seconds_behind_master option for masterha_check_repl"`
 }
 
 func (c replChecker) Execute(args []string) error {
@@ -28,7 +30,19 @@ func (c replChecker) makeCommandName() string {
 }
 
 func (c replChecker) makeCommandArgs() []string {
-	return make([]string, 0, 2)
+	args := make([]string, 0, c.ArgsLength())
+	if c.SecondsBehindMaster > 0 {
+		secondsBehindMaster := strconv.Itoa(c.SecondsBehindMaster)
+		args = append(args, "--seconds_behind_master", secondsBehindMaster)
+	}
+	return args
+}
+
+func (c replChecker) ArgsLength() int {
+	if c.SecondsBehindMaster > 0 {
+		return 4
+	}
+	return 2
 }
 
 func (c replChecker) parse(out string) (checkers.Status, string) {

--- a/check-masterha/check_masterha_repl_test.go
+++ b/check-masterha/check_masterha_repl_test.go
@@ -1,0 +1,144 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/mackerelio/checkers"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMakeReplCommandName(t *testing.T) {
+	name := replSubcommand.MakeCommandName()
+	assert.Equal(t, "masterha_check_repl", name)
+}
+
+func TestMakeReplCommandArgs(t *testing.T) {
+	args := replSubcommand.MakeCommandArgs()
+	assert.Equal(t, 0, len(args))
+}
+
+func TestMakeReplCommandArgsWithSecondsBehindMaster(t *testing.T) {
+	replSubcommand := replChecker{
+		subcommand: subcommand{
+			Config:    "/path/to/masterha/db001.conf",
+			ConfigDir: "/usr/local/masterha/conf",
+			All:       false,
+		},
+		SecondsBehindMaster: 12345,
+	}
+	args := replSubcommand.MakeCommandArgs()
+	assert.Equal(t, 2, len(args))
+	assert.Equal(t, "--seconds_behind_master", args[0])
+	assert.Equal(t, "12345", args[1])
+}
+
+func TestParseReplSuccess(t *testing.T) {
+	body := `Thu Mar 24 14:40:20 2016 - [warn] Global configuration file /etc/masterha_default.cnf not found. Skipping.
+Thu Mar 24 14:40:20 2016 - [info] Reading application default configurations from /usr/local/masterha/conf/db001.cnf..
+Thu Mar 24 14:40:20 2016 - [info] Reading server configurations from /usr/local/masterha/conf/db001.cnf..
+Thu Mar 24 14:40:20 2016 - [info] MHA::MasterMonitor version 0.50.
+Thu Mar 24 14:40:21 2016 - [info] Dead Servers:
+Thu Mar 24 14:40:21 2016 - [info] Alive Servers:
+Thu Mar 24 14:40:21 2016 - [info]   XX.XX.XX.XX(XX.XX.XX.XX:3306)
+Thu Mar 24 14:40:21 2016 - [info]   XX.XX.XX.XX(XX.XX.XX.XX:3306)
+Thu Mar 24 14:40:21 2016 - [info]   XX.XX.XX.XX(XX.XX.XX.XX:3306)
+Thu Mar 24 14:40:21 2016 - [info] Alive Slaves:
+Thu Mar 24 14:40:21 2016 - [info]   XX.XX.XX.XX(XX.XX.XX.XX:3306)  Version=5.6.29-log (oldest major version between slaves) log-bin:enabled
+Thu Mar 24 14:40:21 2016 - [info]     Replicating from XX.XX.XX.XX(XX.XX.XX.XX:3306)
+Thu Mar 24 14:40:21 2016 - [info]   XX.XX.XX.XX(XX.XX.XX.XX:3306)  Version=5.6.29-log (oldest major version between slaves) log-bin:enabled
+Thu Mar 24 14:40:21 2016 - [info]     Replicating from XX.XX.XX.XX(XX.XX.XX.XX:3306)
+Thu Mar 24 14:40:21 2016 - [info]     Not candidate for the new Master (no_master is set)
+Thu Mar 24 14:40:21 2016 - [info] Current Master: XX.XX.XX.XX(XX.XX.XX.XX:3306)
+Thu Mar 24 14:40:21 2016 - [info] Checking slave configurations..
+Thu Mar 24 14:40:21 2016 - [warn]  relay_log_purge=0 is not set on slave XX.XX.XX.XX(XX.XX.XX.XX:3306).
+Thu Mar 24 14:40:21 2016 - [warn]  relay_log_purge=0 is not set on slave XX.XX.XX.XX(XX.XX.XX.XX:3306).
+Thu Mar 24 14:40:21 2016 - [info] Checking replication filtering settings..
+Thu Mar 24 14:40:21 2016 - [info]  binlog_do_db= , binlog_ignore_db=
+Thu Mar 24 14:40:21 2016 - [info]  Replication filtering check ok.
+Thu Mar 24 14:40:21 2016 - [info] Starting SSH connection tests..
+Thu Mar 24 14:40:22 2016 - [info] All SSH connection tests passed successfully.
+Thu Mar 24 14:40:22 2016 - [info] Checking MHA Node version..
+Thu Mar 24 14:40:23 2016 - [info]  Version check ok.
+Thu Mar 24 14:40:23 2016 - [info] Checking SSH publickey authentication and checking recovery script configurations on the current master..
+Thu Mar 24 14:40:23 2016 - [info]   Executing command: save_binary_logs --command=test --start_file=XXXX-bin.XXXXXX --start_pos=1 --binlog_dir=/path/to/lib/mysql,/path/to/log/mysql --output_file=/path/to/log/masterha/db001/save_binary_logs_test --manager_version=0.50
+Thu Mar 24 14:40:23 2016 - [info]   Connecting to mysql@XX.XX.XX.XX(XX.XX.XX.XX)..
+  Creating /path/to/log/masterha/db001 if not exists..    ok.
+  Checking output directory is accessible or not..
+   ok.
+  Binlog found at /path/to/lib/mysql, up to XXXX-bin.XXXXXX
+Thu Mar 24 14:40:23 2016 - [info] Master setting check done.
+Thu Mar 24 14:40:23 2016 - [info] Checking SSH publickey authentication and checking recovery script configurations on all alive slave servers..
+Thu Mar 24 14:40:23 2016 - [info]   Executing command : apply_diff_relay_logs --command=test --slave_user=masterha --slave_host=XX.XX.XX.XX --slave_ip=XX.XX.XX.XX --slave_port=3306 --workdir=/path/to/log/masterha/db001 --target_version=5.6.29-log --manager_version=0.50 --relay_log_info=/path/to/lib/mysql/relay-log.info  --slave_pass=xxx
+Thu Mar 24 14:40:23 2016 - [info]   Connecting to mysql@XX.XX.XX.XX(XX.XX.XX.XX)..
+  Checking slave recovery environment settings..
+    Opening /path/to/lib/mysql/relay-log.info XX.XX.XX.XX ok.
+    Relay log found at /path/to/lib/mysql, up to XXXXX-relay-bin.XXXXXX
+    Temporary relay log file is /path/to/lib/mysql/XXXXX-relay-bin.XXXXXX
+    Testing mysql connection and privileges.. done.
+    Testing mysqlbinlog output.. done.
+    Cleaning up test file(s).. done.
+Thu Mar 24 14:40:23 2016 - [info]   Executing command : apply_diff_relay_logs --command=test --slave_user=masterha --slave_host=XX.XX.XX.XX --slave_ip=XX.XX.XX.XX --slave_port=3306 --workdir=/path/to/log/masterha/db001 --target_version=5.6.29-log --manager_version=0.50 --relay_log_info=/path/to/lib/mysql/relay-log.info  --slave_pass=xxx
+Thu Mar 24 14:40:23 2016 - [info]   Connecting to mysql@XX.XX.XX.XX(XX.XX.XX.XX)..
+  Checking slave recovery environment settings..
+    Opening /path/to/lib/mysql/relay-log.info XX.XX.XX.XX ok.
+    Relay log found at /path/to/lib/mysql, up to XXXXX-relay-bin.XXXXXX
+    Temporary relay log file is /path/to/lib/mysql/XXXXX-relay-bin.XXXXXX
+    Testing mysql connection and privileges.. done.
+    Testing mysqlbinlog output.. done.
+    Cleaning up test file(s).. done.
+Thu Mar 24 14:40:24 2016 - [info] Slaves settings check done.
+Thu Mar 24 14:40:24 2016 - [info]
+XX.XX.XX.XX (current master)
+ +--XX.XX.XX.XX
+ +--XX.XX.XX.XX
+
+Thu Mar 24 14:40:24 2016 - [info] Checking replication health on XX.XX.XX.XX..
+Thu Mar 24 14:40:24 2016 - [info]  ok.
+Thu Mar 24 14:40:24 2016 - [info] Checking replication health on XX.XX.XX.XX..
+Thu Mar 24 14:40:24 2016 - [info]  ok.
+Thu Mar 24 14:40:24 2016 - [info] Checking master_ip_failvoer_script status:
+Thu Mar 24 14:40:24 2016 - [info]   /path/to/failover.sh --command=status --ssh_user=root --orig_master_host=XX.XX.XX.XX --orig_master_ip=XX.XX.XX.XX --orig_master_port=3306
+Thu Mar 24 14:40:24 2016 - [info]  OK.
+Thu Mar 24 14:40:24 2016 - [warn] shutdown_script is not defined.
+Thu Mar 24 14:40:24 2016 - [info] Got exit code 0 (Not master dead).
+
+MySQL Replication Health is OK.
+`
+	status, msg := replSubcommand.Parse(body)
+	assert.Equal(t, checkers.OK, status)
+	assert.Equal(t, "MySQL Replication Health is OK.", msg)
+}
+
+func TestParseReplFailure(t *testing.T) {
+	body := `Thu Mar 24 14:31:00 2016 - [warn] Global configuration file /etc/masterha_default.cnf not found. Skipping.
+Thu Mar 24 14:31:00 2016 - [info] Reading application default configurations from /usr/local/masterha/conf/db001.cnf..
+Thu Mar 24 14:31:00 2016 - [info] Reading server configurations from /usr/local/masterha/conf/db001.cnf..
+Thu Mar 24 14:31:00 2016 - [info] MHA::MasterMonitor version 0.50.
+Thu Mar 24 14:31:01 2016 - [info] Dead Servers:
+Thu Mar 24 14:31:01 2016 - [info] Alive Servers:
+Thu Mar 24 14:31:01 2016 - [info]   XX.XX.XX.XX(XX.XX.XX.XX:3306)
+Thu Mar 24 14:31:01 2016 - [info]   XX.XX.XX.XX(XX.XX.XX.XX:3306)
+Thu Mar 24 14:31:01 2016 - [info]   XX.XX.XX.XX(XX.XX.XX.XX:3306)
+Thu Mar 24 14:31:01 2016 - [info]   XX.XX.XX.XX(XX.XX.XX.XX:3306)
+Thu Mar 24 14:31:01 2016 - [info] Alive Slaves:
+Thu Mar 24 14:31:01 2016 - [info]   XX.XX.XX.XX(XX.XX.XX.XX:3306)  Version=5.6.29-log (oldest major version between slaves) log-bin:enabled
+Thu Mar 24 14:31:01 2016 - [info]     Replicating from XX.XX.XX.XX(XX.XX.XX.XX:3306)
+Thu Mar 24 14:31:01 2016 - [info]     Not candidate for the new Master (no_master is set)
+Thu Mar 24 14:31:01 2016 - [info]   XX.XX.XX.XX(XX.XX.XX.XX:3306)  Version=5.6.29-log (oldest major version between slaves) log-bin:enabled
+Thu Mar 24 14:31:01 2016 - [info]     Replicating from XX.XX.XX.XX(XX.XX.XX.XX:3306)
+Thu Mar 24 14:31:01 2016 - [info]   XX.XX.XX.XX(XX.XX.XX.XX:3306)  Version=5.6.29-log (oldest major version between slaves) log-bin:enabled
+Thu Mar 24 14:31:01 2016 - [info]     Replicating from XX.XX.XX.XX(XX.XX.XX.XX:3306)
+Thu Mar 24 14:31:01 2016 - [info]   XX.XX.XX.XX(XX.XX.XX.XX:3306)  Version=5.6.29-log (oldest major version between slaves) log-bin:enabled
+Thu Mar 24 14:31:01 2016 - [info]     Replicating from XX.XX.XX.XX(XX.XX.XX.XX:3306)
+Thu Mar 24 14:31:01 2016 - [error][/path/to/perl5/MHA/ServerManager.pm, ln522] FATAL: Replication configuration error. All slaves should replicate from the same master.
+Thu Mar 24 14:31:01 2016 - [error][/path/to/perl5/MHA/ServerManager.pm, ln1069] MySQL master is not correctly configured. Check master/slave settings
+Thu Mar 24 14:31:01 2016 - [error][/path/to/perl5/MHA/MasterMonitor.pm, ln316] Error happend on checking configurations.  at /path/to/perl5/MHA/MasterMonitor.pm line 243
+Thu Mar 24 14:31:01 2016 - [error][/path/to/perl5/MHA/MasterMonitor.pm, ln397] Error happened on monitoring servers.
+Thu Mar 24 14:31:01 2016 - [info] Got exit code 1 (Not master dead).
+
+MySQL Replication Health is NOT OK!
+`
+	status, msg := replSubcommand.Parse(body)
+	assert.Equal(t, checkers.CRITICAL, status)
+	assert.Equal(t, "MySQL Replication Health is NOT OK!", msg)
+}

--- a/check-masterha/check_masterha_ssh.go
+++ b/check-masterha/check_masterha_ssh.go
@@ -23,15 +23,15 @@ func (c sshChecker) Execute(args []string) error {
 	return nil
 }
 
-func (c sshChecker) makeCommandName() string {
+func (c sshChecker) MakeCommandName() string {
 	return "masterha_check_ssh"
 }
 
-func (c sshChecker) makeCommandArgs() []string {
+func (c sshChecker) MakeCommandArgs() []string {
 	return make([]string, 0, 2)
 }
 
-func (c sshChecker) parse(out string) (checkers.Status, string) {
+func (c sshChecker) Parse(out string) (checkers.Status, string) {
 	lines := extractNonEmptyLines(strings.Split(out, "\n"))
 	lastLine := lines[len(lines)-1]
 	if strings.Contains(lastLine, "All SSH connection tests passe") {

--- a/check-masterha/check_masterha_ssh.go
+++ b/check-masterha/check_masterha_ssh.go
@@ -7,14 +7,17 @@ import (
 )
 
 type sshChecker struct {
-	Config string `short:"c" long:"conf" required:"true" description:"target config file"`
+	subcommand
 }
 
 func (c sshChecker) Execute(args []string) error {
-	checker, err := executeSubcommand(c)
+	c.Executer = &c
+
+	checker, err := c.executeAll()
 	if err != nil {
 		return err
 	}
+
 	checker.Name = "MasterHA"
 	checker.Exit()
 	return nil
@@ -25,8 +28,7 @@ func (c sshChecker) makeCommandName() string {
 }
 
 func (c sshChecker) makeCommandArgs() []string {
-	args := [2]string{"--conf", c.Config}
-	return args[:]
+	return make([]string, 0, 2)
 }
 
 func (c sshChecker) parse(out string) (checkers.Status, string) {

--- a/check-masterha/check_masterha_ssh.go
+++ b/check-masterha/check_masterha_ssh.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"strings"
+
+	"github.com/mackerelio/checkers"
+)
+
+type sshChecker struct {
+	Config string `short:"c" long:"conf" required:"true" description:"target config file"`
+}
+
+func (c sshChecker) Execute(args []string) error {
+	checker, err := executeSubcommand(c)
+	if err != nil {
+		return err
+	}
+	checker.Name = "MasterHA"
+	checker.Exit()
+	return nil
+}
+
+func (c sshChecker) makeCommandName() string {
+	return "masterha_check_ssh"
+}
+
+func (c sshChecker) makeCommandArgs() []string {
+	args := [2]string{"--conf", c.Config}
+	return args[:]
+}
+
+func (c sshChecker) parse(out string) (checkers.Status, string) {
+	lines := extractNonEmptyLines(strings.Split(out, "\n"))
+	lastLine := lines[len(lines)-1]
+	if strings.Contains(lastLine, "All SSH connection tests passe") {
+		return checkers.OK, lastLine
+	} else if strings.Contains(lastLine, "SSH Configuration Check Failed!") {
+		return checkers.OK, lastLine
+	} else {
+		msg := extractErrorMsg(out)
+		return checkers.UNKNOWN, msg
+	}
+}

--- a/check-masterha/check_masterha_ssh.go
+++ b/check-masterha/check_masterha_ssh.go
@@ -37,7 +37,7 @@ func (c sshChecker) parse(out string) (checkers.Status, string) {
 	if strings.Contains(lastLine, "All SSH connection tests passe") {
 		return checkers.OK, lastLine
 	} else if strings.Contains(lastLine, "SSH Configuration Check Failed!") {
-		return checkers.OK, lastLine
+		return checkers.CRITICAL, lastLine
 	} else {
 		msg := extractErrorMsg(out)
 		return checkers.UNKNOWN, msg

--- a/check-masterha/check_masterha_ssh_test.go
+++ b/check-masterha/check_masterha_ssh_test.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/mackerelio/checkers"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMakeSshCommandName(t *testing.T) {
+	name := sshSubcommand.MakeCommandName()
+	assert.Equal(t, "masterha_check_ssh", name)
+}
+
+func TestMakeSshCommandArgs(t *testing.T) {
+	args := sshSubcommand.MakeCommandArgs()
+	assert.Equal(t, 0, len(args))
+}
+
+func TestParseSshSuccess(t *testing.T) {
+	body := `Thu Mar 24 15:42:56 2016 - [warn] Global configuration file /etc/masterha_default.cnf not found. Skipping.
+Thu Mar 24 15:42:56 2016 - [info] Reading application default configurations from /usr/local/masterha/conf/db001.cnf..
+Thu Mar 24 15:42:56 2016 - [info] Reading server configurations from /usr/local/masterha/conf/db001.cnf..
+Thu Mar 24 15:42:56 2016 - [info] Starting SSH connection tests..
+Thu Mar 24 15:42:57 2016 - [debug]
+Thu Mar 24 15:42:56 2016 - [debug]  Connecting via SSH from mysql@XX.XX.XX.XX(XX.XX.XX.XX) to mysql@XX.XX.XX.XX(XX.XX.XX.XX)..
+Thu Mar 24 15:42:56 2016 - [debug]   ok.
+Thu Mar 24 15:42:56 2016 - [debug]  Connecting via SSH from mysql@XX.XX.XX.XX(XX.XX.XX.XX) to mysql@XX.XX.XX.XX(XX.XX.XX.XX)..
+Thu Mar 24 15:42:56 2016 - [debug]   ok.
+Thu Mar 24 15:42:56 2016 - [debug]  Connecting via SSH from mysql@XX.XX.XX.XX(XX.XX.XX.XX) to mysql@XX.XX.XX.XX(XX.XX.XX.XX)..
+Thu Mar 24 15:42:56 2016 - [debug]   ok.
+Thu Mar 24 15:42:57 2016 - [debug]
+Thu Mar 24 15:42:56 2016 - [debug]  Connecting via SSH from mysql@XX.XX.XX.XX(XX.XX.XX.XX) to mysql@XX.XX.XX.XX(XX.XX.XX.XX)..
+Thu Mar 24 15:42:56 2016 - [debug]   ok.
+Thu Mar 24 15:42:56 2016 - [debug]  Connecting via SSH from mysql@XX.XX.XX.XX(XX.XX.XX.XX) to mysql@XX.XX.XX.XX(XX.XX.XX.XX)..
+Thu Mar 24 15:42:57 2016 - [debug]   ok.
+Thu Mar 24 15:42:57 2016 - [debug]  Connecting via SSH from mysql@XX.XX.XX.XX(XX.XX.XX.XX) to mysql@XX.XX.XX.XX(XX.XX.XX.XX)..
+Thu Mar 24 15:42:57 2016 - [debug]   ok.
+Thu Mar 24 15:42:58 2016 - [debug]
+Thu Mar 24 15:42:57 2016 - [debug]  Connecting via SSH from mysql@XX.XX.XX.XX(XX.XX.XX.XX) to mysql@XX.XX.XX.XX(XX.XX.XX.XX)..
+Thu Mar 24 15:42:57 2016 - [debug]   ok.
+Thu Mar 24 15:42:57 2016 - [debug]  Connecting via SSH from mysql@XX.XX.XX.XX(XX.XX.XX.XX) to mysql@XX.XX.XX.XX(XX.XX.XX.XX)..
+Thu Mar 24 15:42:57 2016 - [debug]   ok.
+Thu Mar 24 15:42:57 2016 - [debug]  Connecting via SSH from mysql@XX.XX.XX.XX(XX.XX.XX.XX) to mysql@XX.XX.XX.XX(XX.XX.XX.XX)..
+Thu Mar 24 15:42:57 2016 - [debug]   ok.
+Thu Mar 24 15:42:58 2016 - [debug]
+Thu Mar 24 15:42:57 2016 - [debug]  Connecting via SSH from mysql@XX.XX.XX.XX(XX.XX.XX.XX) to mysql@XX.XX.XX.XX(XX.XX.XX.XX)..
+Thu Mar 24 15:42:57 2016 - [debug]   ok.
+Thu Mar 24 15:42:57 2016 - [debug]  Connecting via SSH from mysql@XX.XX.XX.XX(XX.XX.XX.XX) to mysql@XX.XX.XX.XX(XX.XX.XX.XX)..
+Thu Mar 24 15:42:58 2016 - [debug]   ok.
+Thu Mar 24 15:42:58 2016 - [debug]  Connecting via SSH from mysql@XX.XX.XX.XX(XX.XX.XX.XX) to mysql@XX.XX.XX.XX(XX.XX.XX.XX)..
+Thu Mar 24 15:42:58 2016 - [debug]   ok.
+Thu Mar 24 15:42:58 2016 - [info] All SSH connection tests passed successfully.
+`
+	status, msg := sshSubcommand.Parse(body)
+	assert.Equal(t, checkers.OK, status)
+	assert.Equal(t, "Thu Mar 24 15:42:58 2016 - [info] All SSH connection tests passed successfully.", msg)
+}
+
+func TestParseSshFailure(t *testing.T) {
+	body := `Thu Mar 24 15:42:56 2016 - [warn] Global configuration file /etc/masterha_default.cnf not found. Skipping.
+Thu Mar 24 15:42:56 2016 - [info] Reading application default configurations from /usr/local/masterha/conf/db001.cnf..
+Thu Mar 24 15:42:56 2016 - [info] Reading server configurations from /usr/local/masterha/conf/db001.cnf..
+Thu Mar 24 15:42:56 2016 - [info] Starting SSH connection tests..
+Thu Mar 24 15:42:57 2016 - [debug]
+Thu Mar 24 15:42:56 2016 - [debug]  Connecting via SSH from mysql@XX.XX.XX.XX(XX.XX.XX.XX) to mysql@XX.XX.XX.XX(XX.XX.XX.XX)..
+Thu Mar 24 15:42:56 2016 - [debug]   ok.
+Thu Mar 24 15:42:56 2016 - [debug]  Connecting via SSH from mysql@XX.XX.XX.XX(XX.XX.XX.XX) to mysql@XX.XX.XX.XX(XX.XX.XX.XX)..
+Thu Mar 24 15:42:56 2016 - [debug]   ok.
+Thu Mar 24 15:42:56 2016 - [debug]  Connecting via SSH from mysql@XX.XX.XX.XX(XX.XX.XX.XX) to mysql@XX.XX.XX.XX(XX.XX.XX.XX)..
+Thu Mar 24 15:42:56 2016 - [debug]   ok.
+Thu Mar 24 15:42:57 2016 - [debug]
+Thu Mar 24 15:42:56 2016 - [debug]  Connecting via SSH from mysql@XX.XX.XX.XX(XX.XX.XX.XX) to mysql@XX.XX.XX.XX(XX.XX.XX.XX)..
+Thu Mar 24 15:42:56 2016 - [debug]   ok.
+Thu Mar 24 15:42:56 2016 - [debug]  Connecting via SSH from mysql@XX.XX.XX.XX(XX.XX.XX.XX) to mysql@XX.XX.XX.XX(XX.XX.XX.XX)..
+Thu Mar 24 15:42:57 2016 - [debug]   ok.
+Thu Mar 24 15:42:57 2016 - [debug]  Connecting via SSH from mysql@XX.XX.XX.XX(XX.XX.XX.XX) to mysql@XX.XX.XX.XX(XX.XX.XX.XX)..
+Thu Mar 24 15:42:57 2016 - [debug]   ok.
+Thu Mar 24 15:42:58 2016 - [debug]
+Thu Mar 24 15:42:57 2016 - [debug]  Connecting via SSH from mysql@XX.XX.XX.XX(XX.XX.XX.XX) to mysql@XX.XX.XX.XX(XX.XX.XX.XX)..
+Thu Mar 24 15:42:57 2016 - [debug]   ok.
+Thu Mar 24 15:42:57 2016 - [debug]  Connecting via SSH from mysql@XX.XX.XX.XX(XX.XX.XX.XX) to mysql@XX.XX.XX.XX(XX.XX.XX.XX)..
+Thu Mar 24 15:42:57 2016 - [debug]   ok.
+Thu Mar 24 15:42:57 2016 - [debug]  Connecting via SSH from mysql@XX.XX.XX.XX(XX.XX.XX.XX) to mysql@XX.XX.XX.XX(XX.XX.XX.XX)..
+Thu Mar 24 15:42:57 2016 - [debug]   ok.
+Thu Mar 24 15:42:58 2016 - [debug]
+Thu Mar 24 15:42:57 2016 - [debug]  Connecting via SSH from mysql@XX.XX.XX.XX(XX.XX.XX.XX) to mysql@XX.XX.XX.XX(XX.XX.XX.XX)..
+Thu Mar 24 15:42:57 2016 - [debug]   ok.
+Thu Mar 24 15:42:57 2016 - [debug]  Connecting via SSH from mysql@XX.XX.XX.XX(XX.XX.XX.XX) to mysql@XX.XX.XX.XX(XX.XX.XX.XX)..
+Thu Mar 24 15:42:58 2016 - [debug]   ok.
+Thu Mar 24 15:42:58 2016 - [debug]  Connecting via SSH from mysql@XX.XX.XX.XX(XX.XX.XX.XX) to mysql@XX.XX.XX.XX(XX.XX.XX.XX)..
+Thu Mar 24 15:42:58 2016 - [error]  SSH connection from mysql@XX.XX.XX.XX(XX.XX.XX.XX) to mysql@XX.XX.XX.XX(XX.XX.XX.XX) failed!
+SSH Configuration Check Failed!
+`
+	status, msg := sshSubcommand.Parse(body)
+	assert.Equal(t, checkers.CRITICAL, status)
+	assert.Equal(t, "SSH Configuration Check Failed!", msg)
+}
+

--- a/check-masterha/check_masterha_status.go
+++ b/check-masterha/check_masterha_status.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"strings"
+
+	"github.com/mackerelio/checkers"
+)
+
+type statusChecker struct {
+	Config string `short:"c" long:"conf" default:"" description:"target config file"`
+	All    bool   `short:"a" long:"all" description:"use all config file for target"`
+}
+
+func (c statusChecker) Execute(args []string) error {
+	checker, err := executeSubcommand(c)
+	if err != nil {
+		return err
+	}
+	checker.Name = "MasterHA"
+	checker.Exit()
+	return nil
+}
+
+func (c statusChecker) makeCommandName() string {
+	return "masterha_check_status"
+}
+
+func (c statusChecker) makeCommandArgs() []string {
+	args := make([]string, 0, 2)
+	if c.All {
+		args = append(args, "--all")
+	} else if c.Config != "" {
+		args = append(args, "--conf", c.Config)
+	}
+	return args
+}
+
+func (c statusChecker) parse(out string) (checkers.Status, string) {
+	lines := strings.Split(out, "\n")
+	errors := make([]string, 0, 0)
+
+	for _, line := range lines {
+		if line != "" && !strings.Contains(line, "running(0:PING_OK)") {
+			errors = append(errors, line)
+		}
+	}
+	if len(errors) == 0 {
+		return checkers.OK, "running(0:PING_OK)"
+	}
+
+	msg := strings.Join(errors, "\n")
+	return checkers.CRITICAL, msg
+}

--- a/check-masterha/check_masterha_status.go
+++ b/check-masterha/check_masterha_status.go
@@ -7,15 +7,17 @@ import (
 )
 
 type statusChecker struct {
-	Config string `short:"c" long:"conf" default:"" description:"target config file"`
-	All    bool   `short:"a" long:"all" description:"use all config file for target"`
+	subcommand
 }
 
 func (c statusChecker) Execute(args []string) error {
-	checker, err := executeSubcommand(c)
+	c.Executer = &c
+
+	checker, err := c.executeAll()
 	if err != nil {
 		return err
 	}
+
 	checker.Name = "MasterHA"
 	checker.Exit()
 	return nil
@@ -26,13 +28,7 @@ func (c statusChecker) makeCommandName() string {
 }
 
 func (c statusChecker) makeCommandArgs() []string {
-	args := make([]string, 0, 2)
-	if c.All {
-		args = append(args, "--all")
-	} else if c.Config != "" {
-		args = append(args, "--conf", c.Config)
-	}
-	return args
+	return make([]string, 0, 2)
 }
 
 func (c statusChecker) parse(out string) (checkers.Status, string) {

--- a/check-masterha/check_masterha_status.go
+++ b/check-masterha/check_masterha_status.go
@@ -23,15 +23,15 @@ func (c statusChecker) Execute(args []string) error {
 	return nil
 }
 
-func (c statusChecker) makeCommandName() string {
+func (c statusChecker) MakeCommandName() string {
 	return "masterha_check_status"
 }
 
-func (c statusChecker) makeCommandArgs() []string {
+func (c statusChecker) MakeCommandArgs() []string {
 	return make([]string, 0, 2)
 }
 
-func (c statusChecker) parse(out string) (checkers.Status, string) {
+func (c statusChecker) Parse(out string) (checkers.Status, string) {
 	lines := strings.Split(out, "\n")
 	errors := make([]string, 0, 0)
 

--- a/check-masterha/check_masterha_status_test.go
+++ b/check-masterha/check_masterha_status_test.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/mackerelio/checkers"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMakeStatusCommandName(t *testing.T) {
+	name := statusSubcommand.MakeCommandName()
+	assert.Equal(t, "masterha_check_status", name)
+}
+
+func TestMakeStatusCommandArgs(t *testing.T) {
+	args := statusSubcommand.MakeCommandArgs()
+	assert.Equal(t, 0, len(args))
+}
+
+func TestParseStatusSuccess(t *testing.T) {
+	body := `db001 (pid:1111) is running(0:PING_OK), master:XX.XX.XX.XX
+`
+	status, msg := statusSubcommand.Parse(body)
+	assert.Equal(t, checkers.OK, status)
+	assert.Equal(t, "running(0:PING_OK)", msg)
+}
+
+func TestParseStatusFailure(t *testing.T) {
+	body := `db001 is stopped(2:NOT_RUNNING).
+`
+	status, msg := statusSubcommand.Parse(body)
+	assert.Equal(t, checkers.CRITICAL, status)
+	assert.Equal(t, "db001 is stopped(2:NOT_RUNNING).", msg)
+}
+

--- a/check-masterha/check_masterha_test.go
+++ b/check-masterha/check_masterha_test.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+	"./mock"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/mackerelio/checkers"
+)
+
+var subc = subcommand{
+	Config:    "/path/to/masterha/db001.conf",
+	ConfigDir: "/usr/local/masterha/conf",
+	All:       false,
+}
+
+var replSubcommand = replChecker{subcommand: subc, SecondsBehindMaster: 0}
+var statusSubcommand = statusChecker{subcommand: subc}
+var sshSubcommand = sshChecker{subcommand: subc}
+
+func TestMain(m *testing.M) {
+	replSubcommand.Executer = &replSubcommand
+	statusSubcommand.Executer = &statusSubcommand
+	sshSubcommand.Executer = &sshSubcommand
+	os.Exit(m.Run())
+}
+
+func TestSubcommandExecuteSuccessful(t *testing.T) {
+	subc := subcommand{
+		Config:    "/path/to/masterha/db001.conf",
+		ConfigDir: "/usr/local/masterha/conf",
+		All:       false,
+		Executer: &mock.Executer{
+			CommandName: "echo",
+			CommandArgs: []string{"hello"},
+			CommandResult: "* should set result to here *",
+			Status: checkers.OK,
+			ParseResult: "OK",
+		},
+	}
+	checker, err := subc.execute("/path/to/masterha/db002.conf")
+	assert.Equal(t, "hello --conf /path/to/masterha/db002.conf\n", subc.Executer.(*mock.Executer).CommandResult)
+	assert.Equal(t, checkers.OK, checker.Status)
+	assert.Equal(t, "OK", checker.Message)
+	assert.Equal(t, nil, err)
+}
+
+func TestSubcommandExecuteUnknown(t *testing.T) {
+	subc := subcommand{
+		Config:    "/path/to/masterha/db001.conf",
+		ConfigDir: "/usr/local/masterha/conf",
+		All:       false,
+		Executer: &mock.Executer{
+			CommandName: "false",
+			CommandArgs: []string{""},
+			CommandResult: "* should set result to here *",
+			Status: checkers.UNKNOWN,
+			ParseResult: "UNKNOWN",
+		},
+	}
+	checker, err := subc.execute(subc.Config)
+	assert.Equal(t, "", subc.Executer.(*mock.Executer).CommandResult)
+	assert.Equal(t, checkers.WARNING, checker.Status)
+	assert.Equal(t, "UNKNOWN", checker.Message)
+	assert.Equal(t, nil, err)
+}
+
+func TestExtractNonEmptyLines(t *testing.T) {
+	lines := strings.Split(`
+db001 (pid:1111) is running(0:PING_OK), master:XX.XX.XX.XX
+db002 (pid:1111) is running(0:PING_OK), master:XX.XX.XX.XX
+db003 (pid:1111) is running(0:PING_OK), master:XX.XX.XX.XX
+`, "\n")
+	assert.Equal(t, 5, len(lines))
+	extracted := extractNonEmptyLines(lines)
+	assert.Equal(t, 3, len(extracted))
+}
+
+
+func TestExtractErrorMsg(t *testing.T) {
+	body := `Thu Mar 24 14:31:00 2016 - [warn] Global configuration file /etc/masterha_default.cnf not found. Skipping.
+Thu Mar 24 14:31:00 2016 - [info] Reading application default configurations from /usr/local/masterha/conf/db001.cnf..
+Thu Mar 24 14:31:00 2016 - [info] Reading server configurations from /usr/local/masterha/conf/db001.cnf..
+Thu Mar 24 14:31:00 2016 - [info] MHA::MasterMonitor version 0.50.
+Thu Mar 24 14:31:01 2016 - [info] Dead Servers:
+Thu Mar 24 14:31:01 2016 - [info] Alive Servers:
+Thu Mar 24 14:31:01 2016 - [info]   XX.XX.XX.XX(XX.XX.XX.XX:3306)
+Thu Mar 24 14:31:01 2016 - [info]   XX.XX.XX.XX(XX.XX.XX.XX:3306)
+Thu Mar 24 14:31:01 2016 - [info]   XX.XX.XX.XX(XX.XX.XX.XX:3306)
+Thu Mar 24 14:31:01 2016 - [info]   XX.XX.XX.XX(XX.XX.XX.XX:3306)
+Thu Mar 24 14:31:01 2016 - [info] Alive Slaves:
+Thu Mar 24 14:31:01 2016 - [info]   XX.XX.XX.XX(XX.XX.XX.XX:3306)  Version=5.6.29-log (oldest major version between slaves) log-bin:enabled
+Thu Mar 24 14:31:01 2016 - [info]     Replicating from XX.XX.XX.XX(XX.XX.XX.XX:3306)
+Thu Mar 24 14:31:01 2016 - [info]     Not candidate for the new Master (no_master is set)
+Thu Mar 24 14:31:01 2016 - [info]   XX.XX.XX.XX(XX.XX.XX.XX:3306)  Version=5.6.29-log (oldest major version between slaves) log-bin:enabled
+Thu Mar 24 14:31:01 2016 - [info]     Replicating from XX.XX.XX.XX(XX.XX.XX.XX:3306)
+Thu Mar 24 14:31:01 2016 - [info]   XX.XX.XX.XX(XX.XX.XX.XX:3306)  Version=5.6.29-log (oldest major version between slaves) log-bin:enabled
+Thu Mar 24 14:31:01 2016 - [info]     Replicating from XX.XX.XX.XX(XX.XX.XX.XX:3306)
+Thu Mar 24 14:31:01 2016 - [info]   XX.XX.XX.XX(XX.XX.XX.XX:3306)  Version=5.6.29-log (oldest major version between slaves) log-bin:enabled
+Thu Mar 24 14:31:01 2016 - [info]     Replicating from XX.XX.XX.XX(XX.XX.XX.XX:3306)
+Thu Mar 24 14:31:01 2016 - [error][/usr/lib/perl5/MHA/ServerManager.pm, ln522] FATAL: Replication configuration error. All slaves should replicate from the same master.
+Thu Mar 24 14:31:01 2016 - [error][/usr/lib/perl5/MHA/ServerManager.pm, ln1069] MySQL master is not correctly configured. Check master/slave settings
+Thu Mar 24 14:31:01 2016 - [error][/usr/lib/perl5/MHA/MasterMonitor.pm, ln316] Error happend on checking configurations.  at /usr/lib/perl5/MHA/MasterMonitor.pm line 243
+Thu Mar 24 14:31:01 2016 - [error][/usr/lib/perl5/MHA/MasterMonitor.pm, ln397] Error happened on monitoring servers.
+Thu Mar 24 14:31:01 2016 - [info] Got exit code 1 (Not master dead).
+
+MySQL Replication Health is NOT OK!
+`
+	extracted := extractErrorMsg(body)
+	assert.Equal(t, 4, len(strings.Split(extracted, "\n")))
+}
+

--- a/check-masterha/mock/masterha.go
+++ b/check-masterha/mock/masterha.go
@@ -1,0 +1,26 @@
+package mock
+
+import (
+	"github.com/mackerelio/checkers"
+)
+
+type Executer struct {
+	CommandName string
+	CommandArgs []string
+	CommandResult string
+	Status checkers.Status
+	ParseResult string
+}
+
+func (e *Executer) MakeCommandName() string {
+	return e.CommandName
+}
+
+func (e *Executer) MakeCommandArgs() []string {
+	return e.CommandArgs
+}
+
+func (e *Executer) Parse(result string) (checkers.Status, string) {
+	e.CommandResult = result
+	return e.Status, e.ParseResult
+}

--- a/check-masterha/mock/masterha.go
+++ b/check-masterha/mock/masterha.go
@@ -4,6 +4,8 @@ import (
 	"github.com/mackerelio/checkers"
 )
 
+
+// Executer is dummy executer for testing
 type Executer struct {
 	CommandName string
 	CommandArgs []string
@@ -12,14 +14,17 @@ type Executer struct {
 	ParseResult string
 }
 
+// MakeCommandName is dummy command name maker for testing
 func (e *Executer) MakeCommandName() string {
 	return e.CommandName
 }
 
+// MakeCommandArgs is dummy command arguments maker for testing
 func (e *Executer) MakeCommandArgs() []string {
 	return e.CommandArgs
 }
 
+// Parse is dummy parse method for testing
 func (e *Executer) Parse(result string) (checkers.Status, string) {
 	e.CommandResult = result
 	return e.Status, e.ParseResult


### PR DESCRIPTION
# check-masterha

## Description

Monitor MasterHA status.

## Usage

```
$ check-masterha --conf /path/to/masterha

```

## Setting

```
[plugin.checks.masterha-status]
command = "/path/to/check-masterha status --all"

[plugin.checks.masterha-repl]
command = "/path/to/check-masterha repl --conf /path/to/masterha_cluster.cnf"

[plugin.checks.masterha-ssh]
command = "/path/to/check-masterha ssh --conf /path/to/masterha_cluster.cnf"
```

## Other

* [Master HA Manager](https://code.google.com/p/mysql-master-ha/)
