### PR TITLE
fix: rpm should not include dir

### DIFF
--- a/packaging/rpm/mackerel-check-plugins.spec
+++ b/packaging/rpm/mackerel-check-plugins.spec
@@ -41,8 +41,8 @@ done
 
 %files
 %defattr(-, root, root, 0755)
-%{__targetdir}
-%{__oldtargetdir}
+%{__targetdir}/*
+%{__oldtargetdir}/*
 
 %changelog
 * Fri Mar 25 2016 <y.songmu@gmail.com> - 0.5.2


### PR DESCRIPTION
If rpm includes dir, following conflict error occurs
```
Transaction check error:
  file /usr/bin from install of mackerel-check-plugins-0.5.2-1.x86_64 conflicts with file from package filesystem-2.4.30-3.8.amzn1.x86_64
  file /usr/bin from install of mackerel-agent-plugins-0.19.2-1.x86_64 conflicts with file from package filesystem-2.4.30-3.8.amzn1.x86_64
```