### PR TITLE
Release version 0.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.6.1 (2016-05-13)
+
+* no panic check-masterha when not found the targets, and refactoring #108 (karupanerura)
+* Use config.json to list up packaging target plugins #109 (stanaka)
+* Keep binaries on old path hard corded #110 (stanaka)
+
+
 ## 0.6.0 (2016-05-10)
 
 * supported gearman ascii protocol for check-tcp #89 (karupanerura)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,6 @@
 ## 0.6.1 (2016-05-13)
 
 * no panic check-masterha when not found the targets, and refactoring #108 (karupanerura)
-* Use config.json to list up packaging target plugins #109 (stanaka)
-* Keep binaries on old path hard corded #110 (stanaka)
 
 
 ## 0.6.0 (2016-05-10)

--- a/packaging/deb/debian/changelog
+++ b/packaging/deb/debian/changelog
@@ -2,10 +2,6 @@ mackerel-check-plugins (0.6.1-1) stable; urgency=low
 
   * no panic check-masterha when not found the targets, and refactoring (by karupanerura)
     <https://github.com/mackerelio/go-check-plugins/pull/108>
-  * Use config.json to list up packaging target plugins (by stanaka)
-    <https://github.com/mackerelio/go-check-plugins/pull/109>
-  * Keep binaries on old path hard corded (by stanaka)
-    <https://github.com/mackerelio/go-check-plugins/pull/110>
 
  -- mackerel <mackerel-developers@hatena.ne.jp>  Fri, 13 May 2016 07:53:48 +0000
 

--- a/packaging/deb/debian/changelog
+++ b/packaging/deb/debian/changelog
@@ -1,3 +1,14 @@
+mackerel-check-plugins (0.6.1-1) stable; urgency=low
+
+  * no panic check-masterha when not found the targets, and refactoring (by karupanerura)
+    <https://github.com/mackerelio/go-check-plugins/pull/108>
+  * Use config.json to list up packaging target plugins (by stanaka)
+    <https://github.com/mackerelio/go-check-plugins/pull/109>
+  * Keep binaries on old path hard corded (by stanaka)
+    <https://github.com/mackerelio/go-check-plugins/pull/110>
+
+ -- mackerel <mackerel-developers@hatena.ne.jp>  Fri, 13 May 2016 07:53:48 +0000
+
 mackerel-check-plugins (0.6.0-1) stable; urgency=low
 
   * supported gearman ascii protocol for check-tcp (by karupanerura)

--- a/packaging/rpm/mackerel-check-plugins.spec
+++ b/packaging/rpm/mackerel-check-plugins.spec
@@ -30,7 +30,7 @@ for i in `cat %{_sourcedir}/packaging/config.json | jq -r '.plugins[]'`; do \
     %{__install} -m0755 %{_sourcedir}/build/check-$i %{buildroot}%{__targetdir}/; \
 done
 
-# put symlinks to /usr/local/bin for backward compatibility of following plugins 
+# put symlinks to /usr/local/bin for backward compatibility of following plugins
 %{__install} -d -m755 %{buildroot}%{__oldtargetdir}
 for i in elasticsearch file-age file-size http jmx-jolokia load log mailq memcached mysql ntpoffset postgresql procs redis solr tcp uptime; do
     ln -s ../../bin/check-$i %{buildroot}%{__oldtargetdir}/check-$i; \
@@ -47,8 +47,6 @@ done
 %changelog
 * Fri May 13 2016 <mackerel-developers@hatena.ne.jp> - 0.6.1-1
 - no panic check-masterha when not found the targets, and refactoring (by karupanerura)
-- Use config.json to list up packaging target plugins (by stanaka)
-- Keep binaries on old path hard corded (by stanaka)
 
 * Tue May 10 2016 <mackerel-developers@hatena.ne.jp> - 0.6.0-1
 - supported gearman ascii protocol for check-tcp (by karupanerura)

--- a/packaging/rpm/mackerel-check-plugins.spec
+++ b/packaging/rpm/mackerel-check-plugins.spec
@@ -45,6 +45,11 @@ done
 %{__oldtargetdir}/*
 
 %changelog
+* Fri May 13 2016 <mackerel-developers@hatena.ne.jp> - 0.6.1-1
+- no panic check-masterha when not found the targets, and refactoring (by karupanerura)
+- Use config.json to list up packaging target plugins (by stanaka)
+- Keep binaries on old path hard corded (by stanaka)
+
 * Tue May 10 2016 <mackerel-developers@hatena.ne.jp> - 0.6.0-1
 - supported gearman ascii protocol for check-tcp (by karupanerura)
 - added check-masterha command to check masterha status (by karupanerura)


### PR DESCRIPTION
- no panic check-masterha when not found the targets, and refactoring #108
- Use config.json to list up packaging target plugins #109
- Keep binaries on old path hard corded #110