### PR TITLE
Add option for skip searching logfile content if logfile does not exist

### DIFF
--- a/check-log/check-log.go
+++ b/check-log/check-log.go
@@ -29,6 +29,7 @@ type logOpts struct {
 	CaseInsensitive bool    `short:"i" long:"icase" description:"Run a case insensitive match"`
 	StateDir        string  `short:"s" long:"state-dir" default:"/var/mackerel-cache/check-log" value-name:"DIR" description:"Dir to keep state files under"`
 	NoState         bool    `long:"no-state" description:"Don't use state file and read whole logs"`
+	SkipNotExist    bool    `long:"skip-not-exist" description:"Skip searching content if LogFile does not exist"`
 	patternReg      *regexp.Regexp
 	excludeReg      *regexp.Regexp
 	fileList        []string
@@ -154,6 +155,9 @@ func (opts *logOpts) searchLog(logFile string) (int64, int64, string, error) {
 
 	f, err := os.Open(logFile)
 	if err != nil {
+		if opts.SkipNotExist {
+			return 0, 0, "", nil
+		}
 		return 0, 0, "", err
 	}
 	defer f.Close()

--- a/check-log/check-log.go
+++ b/check-log/check-log.go
@@ -29,7 +29,7 @@ type logOpts struct {
 	CaseInsensitive bool    `short:"i" long:"icase" description:"Run a case insensitive match"`
 	StateDir        string  `short:"s" long:"state-dir" default:"/var/mackerel-cache/check-log" value-name:"DIR" description:"Dir to keep state files under"`
 	NoState         bool    `long:"no-state" description:"Don't use state file and read whole logs"`
-	Missing         string  `long:"missing" default:"" value-name:"(CRITICAL|WARNING|OK|UNKNOWN)" description:"Exit status when log files missing"`
+	Missing         string  `long:"missing" default:"UNKNOWN" value-name:"(CRITICAL|WARNING|OK|UNKNOWN)" description:"Exit status when log files missing"`
 	patternReg      *regexp.Regexp
 	excludeReg      *regexp.Regexp
 	fileList        []string

--- a/check-log/check-log.go
+++ b/check-log/check-log.go
@@ -79,7 +79,7 @@ func (opts *logOpts) prepare() error {
 			}
 		}
 	}
-	if !(validateMissing(opts.Missing)) {
+	if !validateMissing(opts.Missing) {
 		return fmt.Errorf("missing option is invalid")
 	}
 	return nil

--- a/check-log/check-log.go
+++ b/check-log/check-log.go
@@ -133,6 +133,7 @@ func run(args []string) *checkers.Checker {
 		_, err := os.Stat(f)
 		if err != nil {
 			missingNum++
+			continue
 		}
 		w, c, errLines, err := opts.searchLog(f)
 		if err != nil {
@@ -184,9 +185,6 @@ func (opts *logOpts) searchLog(logFile string) (int64, int64, string, error) {
 
 	f, err := os.Open(logFile)
 	if err != nil {
-		if opts.Missing != "" {
-			return 0, 0, "", nil
-		}
 		return 0, 0, "", err
 	}
 	defer f.Close()

--- a/check-log/check-log.go
+++ b/check-log/check-log.go
@@ -126,13 +126,13 @@ func run(args []string) *checkers.Checker {
 
 	warnNum := int64(0)
 	critNum := int64(0)
-	missingNum := int64(0)
+	var missingFiles []string
 	errorOverall := ""
 
 	for _, f := range opts.fileList {
 		_, err := os.Stat(f)
 		if err != nil {
-			missingNum++
+			missingFiles = append(missingFiles, f)
 			continue
 		}
 		w, c, errLines, err := opts.searchLog(f)
@@ -151,7 +151,7 @@ func run(args []string) *checkers.Checker {
 		msg += "\n" + errorOverall
 	}
 	checkSt := checkers.OK
-	if missingNum > 0 {
+	if len(missingFiles) > 0 {
 		switch opts.Missing {
 		case "OK":
 		case "WARNING":
@@ -161,7 +161,10 @@ func run(args []string) *checkers.Checker {
 		default:
 			checkSt = checkers.UNKNOWN
 		}
-		msg += "\n" + fmt.Sprintf("%d files missing.", missingNum)
+		msg += "\n" + fmt.Sprintf("%d files missing as follows.", len(missingFiles))
+		for _, f := range missingFiles {
+			msg += "\n" + f
+		}
 	}
 	if warnNum > opts.WarnOver {
 		checkSt = checkers.WARNING

--- a/check-log/check-log.go
+++ b/check-log/check-log.go
@@ -161,7 +161,7 @@ func run(args []string) *checkers.Checker {
 		default:
 			checkSt = checkers.UNKNOWN
 		}
-		msg += "\n" + fmt.Sprintf("%d files missing as follows.", len(missingFiles))
+		msg += "\n" + fmt.Sprintf("The following %d files are missing.", len(missingFiles))
 		for _, f := range missingFiles {
 			msg += "\n" + f
 		}

--- a/check-log/check-log.go
+++ b/check-log/check-log.go
@@ -79,6 +79,9 @@ func (opts *logOpts) prepare() error {
 			}
 		}
 	}
+	if !(validateMissing(opts.Missing)) {
+		return fmt.Errorf("missing option is invalid")
+	}
 	return nil
 }
 
@@ -93,6 +96,15 @@ func regCompileWithCase(ptn string, caseInsensitive bool) (*regexp.Regexp, error
 		ptn = "(?i)" + ptn
 	}
 	return regexp.Compile(ptn)
+}
+
+func validateMissing(missing string) bool {
+	switch missing {
+	case "WARNING", "OK", "":
+		return true
+	default:
+		return false
+	}
 }
 
 func parseArgs(args []string) (*logOpts, error) {

--- a/check-log/check_log_test.go
+++ b/check-log/check_log_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/mackerelio/checkers"
 )
 
 func TestGetStateFile(t *testing.T) {
@@ -306,7 +307,7 @@ Fatal level:17
 	assert.Equal(t, int64(len(content)), readBytes, "readBytes should be 26")
 }
 
-func TestRunWithSkipNotExist(t *testing.T) {
+func TestRunWithMissingOk(t *testing.T) {
 	dir, err := ioutil.TempDir("", "check-log-test")
 	if err != nil {
 		t.Errorf("something went wrong")
@@ -316,15 +317,56 @@ func TestRunWithSkipNotExist(t *testing.T) {
 	logf := filepath.Join(dir, "dummy")
 
 	ptn := `FATAL`
-	opts, _ := parseArgs([]string{"-s", dir, "-f", logf, "-p", ptn, "--skip-not-exist"})
+	missing := `OK`
+	params := []string{"-s", dir, "-f", logf, "-p", ptn, "--missing", missing}
+	opts, _ := parseArgs(params)
 	opts.prepare()
 
-	testLogFileNotExist := func() {
+	testLogFileMissing := func() {
 		w, c, errLines, err := opts.searchLog(logf)
 		assert.Equal(t, err, nil, "err should be nil")
 		assert.Equal(t, int64(0), w, "something went wrong")
 		assert.Equal(t, int64(0), c, "something went wrong")
 		assert.Equal(t, "", errLines, "something went wrong")
 	}
-	testLogFileNotExist()
+	testLogFileMissing()
+
+	testRunLogFileMissing := func() {
+		ckr := run(params)
+		assert.Equal(t, ckr.Status, checkers.OK, "ckr.Status should be OK")
+		assert.Equal(t, ckr.Message, "0 warnings, 0 criticals for pattern /FATAL/.", "something went wrong")
+	}
+	testRunLogFileMissing()
+}
+
+func TestRunWithMissingWarning(t *testing.T) {
+	dir, err := ioutil.TempDir("", "check-log-test")
+	if err != nil {
+		t.Errorf("something went wrong")
+	}
+	defer os.RemoveAll(dir)
+
+	logf := filepath.Join(dir, "dummy")
+
+	ptn := `FATAL`
+	missing := `WARNING`
+	params := []string{"-s", dir, "-f", logf, "-p", ptn, "--missing", missing}
+	opts, _ := parseArgs(params)
+	opts.prepare()
+
+	testLogFileMissing := func() {
+		w, c, errLines, err := opts.searchLog(logf)
+		assert.Equal(t, err, nil, "err should be nil")
+		assert.Equal(t, int64(0), w, "something went wrong")
+		assert.Equal(t, int64(0), c, "something went wrong")
+		assert.Equal(t, "", errLines, "something went wrong")
+	}
+	testLogFileMissing()
+
+	testRunLogFileMissing := func() {
+		ckr := run(params)
+		assert.Equal(t, ckr.Status, checkers.WARNING, "ckr.Status should be WARNING")
+		assert.Equal(t, ckr.Message, "0 warnings, 0 criticals for pattern /FATAL/.\n1 files missing.", "something went wrong")
+	}
+	testRunLogFileMissing()
 }

--- a/check-log/check_log_test.go
+++ b/check-log/check_log_test.go
@@ -305,3 +305,26 @@ Fatal level:17
 	assert.Equal(t, "FATAL level:22\nFatal level:17\n", errLines, "invalid errLines")
 	assert.Equal(t, int64(len(content)), readBytes, "readBytes should be 26")
 }
+
+func TestRunWithSkipNotExist(t *testing.T) {
+	dir, err := ioutil.TempDir("", "check-log-test")
+	if err != nil {
+		t.Errorf("something went wrong")
+	}
+	defer os.RemoveAll(dir)
+
+	logf := filepath.Join(dir, "dummy")
+
+	ptn := `FATAL`
+	opts, _ := parseArgs([]string{"-s", dir, "-f", logf, "-p", ptn, "--skip-not-exist"})
+	opts.prepare()
+
+	testLogFileNotExist := func() {
+		w, c, errLines, err := opts.searchLog(logf)
+		assert.Equal(t, err, nil, "err should be nil")
+		assert.Equal(t, int64(0), w, "something went wrong")
+		assert.Equal(t, int64(0), c, "something went wrong")
+		assert.Equal(t, "", errLines, "something went wrong")
+	}
+	testLogFileNotExist()
+}

--- a/check-log/check_log_test.go
+++ b/check-log/check_log_test.go
@@ -323,15 +323,6 @@ func TestRunWithMissingOk(t *testing.T) {
 	opts, _ := parseArgs(params)
 	opts.prepare()
 
-	testLogFileMissing := func() {
-		w, c, errLines, err := opts.searchLog(logf)
-		assert.Equal(t, err, nil, "err should be nil")
-		assert.Equal(t, int64(0), w, "something went wrong")
-		assert.Equal(t, int64(0), c, "something went wrong")
-		assert.Equal(t, "", errLines, "something went wrong")
-	}
-	testLogFileMissing()
-
 	testRunLogFileMissing := func() {
 		ckr := run(params)
 		assert.Equal(t, ckr.Status, checkers.OK, "ckr.Status should be OK")
@@ -354,15 +345,6 @@ func TestRunWithMissingWarning(t *testing.T) {
 	params := []string{"-s", dir, "-f", logf, "-p", ptn, "--missing", missing}
 	opts, _ := parseArgs(params)
 	opts.prepare()
-
-	testLogFileMissing := func() {
-		w, c, errLines, err := opts.searchLog(logf)
-		assert.Equal(t, err, nil, "err should be nil")
-		assert.Equal(t, int64(0), w, "something went wrong")
-		assert.Equal(t, int64(0), c, "something went wrong")
-		assert.Equal(t, "", errLines, "something went wrong")
-	}
-	testLogFileMissing()
 
 	testRunLogFileMissing := func() {
 		ckr := run(params)
@@ -387,15 +369,6 @@ func TestRunWithMissingCritical(t *testing.T) {
 	opts, _ := parseArgs(params)
 	opts.prepare()
 
-	testLogFileMissing := func() {
-		w, c, errLines, err := opts.searchLog(logf)
-		assert.Equal(t, err, nil, "err should be nil")
-		assert.Equal(t, int64(0), w, "something went wrong")
-		assert.Equal(t, int64(0), c, "something went wrong")
-		assert.Equal(t, "", errLines, "something went wrong")
-	}
-	testLogFileMissing()
-
 	testRunLogFileMissing := func() {
 		ckr := run(params)
 		assert.Equal(t, ckr.Status, checkers.CRITICAL, "ckr.Status should be CRITICAL")
@@ -418,15 +391,6 @@ func TestRunWithMissingUnknown(t *testing.T) {
 	params := []string{"-s", dir, "-f", logf, "-p", ptn, "--missing", missing}
 	opts, _ := parseArgs(params)
 	opts.prepare()
-
-	testLogFileMissing := func() {
-		w, c, errLines, err := opts.searchLog(logf)
-		assert.Equal(t, err, nil, "err should be nil")
-		assert.Equal(t, int64(0), w, "something went wrong")
-		assert.Equal(t, int64(0), c, "something went wrong")
-		assert.Equal(t, "", errLines, "something went wrong")
-	}
-	testLogFileMissing()
 
 	testRunLogFileMissing := func() {
 		ckr := run(params)

--- a/check-log/check_log_test.go
+++ b/check-log/check_log_test.go
@@ -327,7 +327,7 @@ func TestRunWithMissingOk(t *testing.T) {
 	testRunLogFileMissing := func() {
 		ckr := run(params)
 		assert.Equal(t, ckr.Status, checkers.OK, "ckr.Status should be OK")
-		msg := fmt.Sprintf("0 warnings, 0 criticals for pattern /FATAL/.\n1 files missing as follows.\n%s", logf)
+		msg := fmt.Sprintf("0 warnings, 0 criticals for pattern /FATAL/.\nThe following 1 files are missing.\n%s", logf)
 		assert.Equal(t, ckr.Message, msg, "something went wrong")
 	}
 	testRunLogFileMissing()
@@ -351,7 +351,7 @@ func TestRunWithMissingWarning(t *testing.T) {
 	testRunLogFileMissing := func() {
 		ckr := run(params)
 		assert.Equal(t, ckr.Status, checkers.WARNING, "ckr.Status should be WARNING")
-		msg := fmt.Sprintf("0 warnings, 0 criticals for pattern /FATAL/.\n1 files missing as follows.\n%s", logf)
+		msg := fmt.Sprintf("0 warnings, 0 criticals for pattern /FATAL/.\nThe following 1 files are missing.\n%s", logf)
 		assert.Equal(t, ckr.Message, msg, "something went wrong")
 	}
 	testRunLogFileMissing()
@@ -375,7 +375,7 @@ func TestRunWithMissingCritical(t *testing.T) {
 	testRunLogFileMissing := func() {
 		ckr := run(params)
 		assert.Equal(t, ckr.Status, checkers.CRITICAL, "ckr.Status should be CRITICAL")
-		msg := fmt.Sprintf("0 warnings, 0 criticals for pattern /FATAL/.\n1 files missing as follows.\n%s", logf)
+		msg := fmt.Sprintf("0 warnings, 0 criticals for pattern /FATAL/.\nThe following 1 files are missing.\n%s", logf)
 		assert.Equal(t, ckr.Message, msg, "something went wrong")
 	}
 	testRunLogFileMissing()
@@ -399,7 +399,7 @@ func TestRunWithMissingUnknown(t *testing.T) {
 	testRunLogFileMissing := func() {
 		ckr := run(params)
 		assert.Equal(t, ckr.Status, checkers.UNKNOWN, "ckr.Status should be UNKNOWN")
-		msg := fmt.Sprintf("0 warnings, 0 criticals for pattern /FATAL/.\n1 files missing as follows.\n%s", logf)
+		msg := fmt.Sprintf("0 warnings, 0 criticals for pattern /FATAL/.\nThe following 1 files are missing.\n%s", logf)
 		assert.Equal(t, ckr.Message, msg, "something went wrong")
 	}
 	testRunLogFileMissing()

--- a/check-log/check_log_test.go
+++ b/check-log/check_log_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -326,7 +327,8 @@ func TestRunWithMissingOk(t *testing.T) {
 	testRunLogFileMissing := func() {
 		ckr := run(params)
 		assert.Equal(t, ckr.Status, checkers.OK, "ckr.Status should be OK")
-		assert.Equal(t, ckr.Message, "0 warnings, 0 criticals for pattern /FATAL/.\n1 files missing.", "something went wrong")
+		msg := fmt.Sprintf("0 warnings, 0 criticals for pattern /FATAL/.\n1 files missing as follows.\n%s", logf)
+		assert.Equal(t, ckr.Message, msg, "something went wrong")
 	}
 	testRunLogFileMissing()
 }
@@ -349,7 +351,8 @@ func TestRunWithMissingWarning(t *testing.T) {
 	testRunLogFileMissing := func() {
 		ckr := run(params)
 		assert.Equal(t, ckr.Status, checkers.WARNING, "ckr.Status should be WARNING")
-		assert.Equal(t, ckr.Message, "0 warnings, 0 criticals for pattern /FATAL/.\n1 files missing.", "something went wrong")
+		msg := fmt.Sprintf("0 warnings, 0 criticals for pattern /FATAL/.\n1 files missing as follows.\n%s", logf)
+		assert.Equal(t, ckr.Message, msg, "something went wrong")
 	}
 	testRunLogFileMissing()
 }
@@ -372,7 +375,8 @@ func TestRunWithMissingCritical(t *testing.T) {
 	testRunLogFileMissing := func() {
 		ckr := run(params)
 		assert.Equal(t, ckr.Status, checkers.CRITICAL, "ckr.Status should be CRITICAL")
-		assert.Equal(t, ckr.Message, "0 warnings, 0 criticals for pattern /FATAL/.\n1 files missing.", "something went wrong")
+		msg := fmt.Sprintf("0 warnings, 0 criticals for pattern /FATAL/.\n1 files missing as follows.\n%s", logf)
+		assert.Equal(t, ckr.Message, msg, "something went wrong")
 	}
 	testRunLogFileMissing()
 }
@@ -395,7 +399,8 @@ func TestRunWithMissingUnknown(t *testing.T) {
 	testRunLogFileMissing := func() {
 		ckr := run(params)
 		assert.Equal(t, ckr.Status, checkers.UNKNOWN, "ckr.Status should be UNKNOWN")
-		assert.Equal(t, ckr.Message, "0 warnings, 0 criticals for pattern /FATAL/.\n1 files missing.", "something went wrong")
+		msg := fmt.Sprintf("0 warnings, 0 criticals for pattern /FATAL/.\n1 files missing as follows.\n%s", logf)
+		assert.Equal(t, ckr.Message, msg, "something went wrong")
 	}
 	testRunLogFileMissing()
 }

--- a/check-log/check_log_test.go
+++ b/check-log/check_log_test.go
@@ -288,6 +288,7 @@ func TestSearchReaderWithLevel(t *testing.T) {
 		Pattern:         `FATAL level:([0-9]+)`,
 		WarnLevel:       11,
 		CritLevel:       17,
+		Missing:         "UNKNOWN",
 	}, opts) {
 		t.Errorf("something went wrong")
 	}


### PR DESCRIPTION
`check-log` exit `UNKNOWN` if logfile which specified by `LogFile` does not exist.
This pull request is add `skip-not-exist` option for skip searching logfile content if logfile does not exist.