### PR TITLE
fix check-mysql replication to detect IO thread 'Connecting'

### DIFF
--- a/check-mysql/replication.go
+++ b/check-mysql/replication.go
@@ -45,7 +45,7 @@ func checkReplication(args []string) *checkers.Checker {
 	sqlThreadStatus := rows[0].Str(idxSQLThreadRunning)
 	secondsBehindMaster := rows[0].Int64(idxSecondsBehindMaster)
 
-	if ioThreadStatus == "No" || sqlThreadStatus == "No" {
+	if !(ioThreadStatus == "Yes" && sqlThreadStatus == "Yes") {
 		return checkers.Critical("MySQL replication has been stopped")
 	}
 


### PR DESCRIPTION
Look at the below image. When MySQL slave try to connect to the master but failed, IO thread status will be "Connecting". In this case, `check-mysql replication` cannot detect replication stop.  This pull request fixes it.

<img width="708" alt="check-mysql-bug" src="https://cloud.githubusercontent.com/assets/621569/17917705/d4af3e2e-69f9-11e6-9c81-1db251f018a0.png">
