### PR TITLE
[file-age] Remove unnecessary newline

### DIFF
--- a/check-file-age/check_file_age.go
+++ b/check-file-age/check_file_age.go
@@ -96,6 +96,6 @@ func run(args []string) *checkers.Checker {
 		result = checkers.CRITICAL
 	}
 
-	msg := fmt.Sprintf("%s is %d seconds old (%02d:%02d:%02d) and %d bytes.\n", opts.File, age, mtime.Hour(), mtime.Minute(), mtime.Second(), size)
+	msg := fmt.Sprintf("%s is %d seconds old (%02d:%02d:%02d) and %d bytes.", opts.File, age, mtime.Hour(), mtime.Minute(), mtime.Second(), size)
 	return checkers.NewChecker(result, msg)
 }


### PR DESCRIPTION
I got a message with a extra newline.
A newline is specified although it has been already added in `ckr.Exit()`

Like this:

```console
$ ./check-file-age -w 200 -f ./check-file-age
FileAge WARNING: ./check-file-age is 544 seconds old (10:50:04) and 2629472 bytes.

$
```