### PR TITLE
Release version 0.6.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.6.3 (2016-09-07)
+
+* fix check-mysql replication to detect IO thread 'Connecting' #116 (hiroakis)
+* [file-age] Remove unnecessary newline #117 (b4b4r07)
+
+
 ## 0.6.2 (2016-06-23)
 
 * Fixed argument parser error: #113 (karupanerura)

--- a/packaging/deb/debian/changelog
+++ b/packaging/deb/debian/changelog
@@ -1,3 +1,12 @@
+mackerel-check-plugins (0.6.3-1) stable; urgency=low
+
+  * fix check-mysql replication to detect IO thread 'Connecting' (by hiroakis)
+    <https://github.com/mackerelio/go-check-plugins/pull/116>
+  * [file-age] Remove unnecessary newline (by b4b4r07)
+    <https://github.com/mackerelio/go-check-plugins/pull/117>
+
+ -- mackerel <mackerel-developers@hatena.ne.jp>  Wed, 07 Sep 2016 03:33:37 +0000
+
 mackerel-check-plugins (0.6.2-1) stable; urgency=low
 
   * Fixed argument parser error: (by karupanerura)

--- a/packaging/rpm/mackerel-check-plugins.spec
+++ b/packaging/rpm/mackerel-check-plugins.spec
@@ -45,6 +45,10 @@ done
 %{__oldtargetdir}/*
 
 %changelog
+* Wed Sep 07 2016 <mackerel-developers@hatena.ne.jp> - 0.6.3-1
+- fix check-mysql replication to detect IO thread 'Connecting' (by hiroakis)
+- [file-age] Remove unnecessary newline (by b4b4r07)
+
 * Thu Jun 23 2016 <mackerel-developers@hatena.ne.jp> - 0.6.2-1
 - Fixed argument parser error: (by karupanerura)
 


### PR DESCRIPTION
- fix check-mysql replication to detect IO thread 'Connecting' #116
- [file-age] Remove unnecessary newline #117