### PR TITLE
[check-log] [incompatible] Chagne state file naming strategy and location

### DIFF
--- a/check-log/check-log.go
+++ b/check-log/check-log.go
@@ -28,7 +28,7 @@ type logOpts struct {
 	ReturnContent   bool    `short:"r" long:"return" description:"Return matched line"`
 	FilePattern     string  `short:"F" long:"file-pattern" value-name:"FILE" description:"Check a pattern of files, instead of one file"`
 	CaseInsensitive bool    `short:"i" long:"icase" description:"Run a case insensitive match"`
-	StateDir        string  `short:"s" long:"state-dir" default:"/var/mackerel-cache/check-log" value-name:"DIR" description:"Dir to keep state files under"`
+	StateDir        string  `short:"s" long:"state-dir" value-name:"DIR" description:"Dir to keep state files under"`
 	NoState         bool    `long:"no-state" description:"Don't use state file and read whole logs"`
 	Missing         string  `long:"missing" default:"UNKNOWN" value-name:"(CRITICAL|WARNING|OK|UNKNOWN)" description:"Exit status when log files missing"`
 	patternReg      *regexp.Regexp
@@ -115,6 +115,13 @@ func parseArgs(args []string) (*logOpts, error) {
 	opts := &logOpts{}
 	_, err := flags.ParseArgs(opts, args)
 	opts.origArgs = origArgs
+	if opts.StateDir == "" {
+		workdir := os.Getenv("MACKEREL_PLUGIN_WORKDIR")
+		if workdir == "" {
+			workdir = os.TempDir()
+		}
+		opts.StateDir = filepath.Join(workdir, "check-log")
+	}
 	return opts, err
 }
 

--- a/check-log/check_log_test.go
+++ b/check-log/check_log_test.go
@@ -14,11 +14,11 @@ import (
 )
 
 func TestGetStateFile(t *testing.T) {
-	sPath := getStateFile("/var/lib", "C:/Windows/hoge")
-	assert.Equal(t, sPath, "/var/lib/C/Windows/hoge", "drive letter should be cared")
+	sPath := getStateFile("/var/lib", "C:/Windows/hoge", "")
+	assert.Equal(t, "/var/lib/C/Windows/hoge-d41d8cd98f00b204e9800998ecf8427e", sPath, "drive letter should be cared")
 
-	sPath = getStateFile("/var/lib", "/linux/hoge")
-	assert.Equal(t, sPath, "/var/lib/linux/hoge", "drive letter should be cared")
+	sPath = getStateFile("/var/lib", "/linux/hoge", "")
+	assert.Equal(t, "/var/lib/linux/hoge-d41d8cd98f00b204e9800998ecf8427e", sPath, "drive letter should be cared")
 }
 
 func TestWriteBytesToSkip(t *testing.T) {
@@ -74,7 +74,7 @@ func TestRun(t *testing.T) {
 	opts, _ := parseArgs([]string{"-s", dir, "-f", logf, "-p", ptn})
 	opts.prepare()
 
-	stateFile := getStateFile(opts.StateDir, logf)
+	stateFile := getStateFile(opts.StateDir, logf, opts.Pattern)
 
 	bytes, _ := getBytesToSkip(stateFile)
 	assert.Equal(t, int64(0), bytes, "something went wrong")
@@ -202,7 +202,7 @@ func TestRunWithMiddleOfLine(t *testing.T) {
 	opts, _ := parseArgs([]string{"-s", dir, "-f", logf, "-p", ptn})
 	opts.prepare()
 
-	stateFile := getStateFile(opts.StateDir, logf)
+	stateFile := getStateFile(opts.StateDir, logf, opts.Pattern)
 
 	bytes, _ := getBytesToSkip(stateFile)
 	assert.Equal(t, int64(0), bytes, "something went wrong")

--- a/check-log/check_log_test.go
+++ b/check-log/check_log_test.go
@@ -14,10 +14,10 @@ import (
 )
 
 func TestGetStateFile(t *testing.T) {
-	sPath := getStateFile("/var/lib", "C:/Windows/hoge", "")
+	sPath := getStateFile("/var/lib", "C:/Windows/hoge", []string{})
 	assert.Equal(t, "/var/lib/C/Windows/hoge-d41d8cd98f00b204e9800998ecf8427e", sPath, "drive letter should be cared")
 
-	sPath = getStateFile("/var/lib", "/linux/hoge", "")
+	sPath = getStateFile("/var/lib", "/linux/hoge", []string{})
 	assert.Equal(t, "/var/lib/linux/hoge-d41d8cd98f00b204e9800998ecf8427e", sPath, "drive letter should be cared")
 }
 
@@ -74,7 +74,7 @@ func TestRun(t *testing.T) {
 	opts, _ := parseArgs([]string{"-s", dir, "-f", logf, "-p", ptn})
 	opts.prepare()
 
-	stateFile := getStateFile(opts.StateDir, logf, opts.Pattern)
+	stateFile := getStateFile(opts.StateDir, logf, opts.origArgs)
 
 	bytes, _ := getBytesToSkip(stateFile)
 	assert.Equal(t, int64(0), bytes, "something went wrong")
@@ -202,7 +202,7 @@ func TestRunWithMiddleOfLine(t *testing.T) {
 	opts, _ := parseArgs([]string{"-s", dir, "-f", logf, "-p", ptn})
 	opts.prepare()
 
-	stateFile := getStateFile(opts.StateDir, logf, opts.Pattern)
+	stateFile := getStateFile(opts.StateDir, logf, opts.origArgs)
 
 	bytes, _ := getBytesToSkip(stateFile)
 	assert.Equal(t, int64(0), bytes, "something went wrong")


### PR DESCRIPTION
Name of state file is frequently conflict in current implement. So I change the strategy.