### PR TITLE
remove checking Ignore

### DIFF
--- a/check-ntservice/check_ntservice.go
+++ b/check-ntservice/check_ntservice.go
@@ -66,9 +66,6 @@ func run(args []string) *checkers.Checker {
 		if s.State == "Running" {
 			continue
 		}
-		if s.ErrorControl == "Ignore" {
-			continue
-		}
 		checkSt = checkers.CRITICAL
 		msg = fmt.Sprintf("%s: %s - %s", s.Name, s.Caption, s.State)
 		break


### PR DESCRIPTION
ErrorControl mean how the errors is noticed to users. Not to check the status of process.