### PR TITLE
Release version 0.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.9.1 (2017-01-11)
+
+* Fix check load #4 (Songmu)
+* Release version 0.0.1 #7 (itchyny)
+* fix MatchSelf behaviour #9 (Songmu)
+* add check-windows-eventlog #129 (daiksy)
+* [check-log]fix encoding option #131 (daiksy)
+* Release version 0.9.0 #132 (astj)
+
+
 ## 0.8.1 (2016-11-29)
 
 * Fix state in check-procs #124 (itchyny)

--- a/packaging/deb/debian/changelog
+++ b/packaging/deb/debian/changelog
@@ -1,3 +1,20 @@
+mackerel-check-plugins (0.9.1-1) stable; urgency=low
+
+  * Fix check load (by Songmu)
+    <https://github.com/mackerelio/go-check-plugins/pull/4>
+  * Release version 0.0.1 (by itchyny)
+    <https://github.com/mackerelio/go-check-plugins/pull/7>
+  * fix MatchSelf behaviour (by Songmu)
+    <https://github.com/mackerelio/go-check-plugins/pull/9>
+  * add check-windows-eventlog (by daiksy)
+    <https://github.com/mackerelio/go-check-plugins/pull/129>
+  * [check-log]fix encoding option (by daiksy)
+    <https://github.com/mackerelio/go-check-plugins/pull/131>
+  * Release version 0.9.0 (by astj)
+    <https://github.com/mackerelio/go-check-plugins/pull/132>
+
+ -- mackerel <mackerel-developers@hatena.ne.jp>  Wed, 11 Jan 2017 03:12:57 +0000
+
 mackerel-check-plugins (0.8.1-1) stable; urgency=low
 
   * Fix state in check-procs (by itchyny)

--- a/packaging/rpm/mackerel-check-plugins.spec
+++ b/packaging/rpm/mackerel-check-plugins.spec
@@ -45,6 +45,14 @@ done
 %{__oldtargetdir}/*
 
 %changelog
+* Wed Jan 11 2017 <mackerel-developers@hatena.ne.jp> - 0.9.1-1
+- Fix check load (by Songmu)
+- Release version 0.0.1 (by itchyny)
+- fix MatchSelf behaviour (by Songmu)
+- add check-windows-eventlog (by daiksy)
+- [check-log]fix encoding option (by daiksy)
+- Release version 0.9.0 (by astj)
+
 * Tue Nov 29 2016 <mackerel-developers@hatena.ne.jp> - 0.8.1-1
 - Fix state in check-procs (by itchyny)
 - Fix the links to the document (by itchyny)


### PR DESCRIPTION
- Fix check load #4
- Release version 0.0.1 #7
- fix MatchSelf behaviour #9
- add check-windows-eventlog #129
- [check-log]fix encoding option #131
- Release version 0.9.0 #132