### PR TITLE
Release version 0.9.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.9.3 (2017-02-08)
+
+* fix matching for 'Audit Success' and 'Audit Failure' #139 (mattn)
+
+
 ## 0.9.2 (2017-01-25)
 
 * [check-windows-eventlog] add --source-exclude, --message-exclude and --event-id #136 (mattn, daiksy)

--- a/packaging/deb/debian/changelog
+++ b/packaging/deb/debian/changelog
@@ -1,3 +1,10 @@
+mackerel-check-plugins (0.9.3-1) stable; urgency=low
+
+  * fix matching for 'Audit Success' and 'Audit Failure' (by mattn)
+    <https://github.com/mackerelio/go-check-plugins/pull/139>
+
+ -- mackerel <mackerel-developers@hatena.ne.jp>  Wed, 08 Feb 2017 01:52:19 +0000
+
 mackerel-check-plugins (0.9.2-1) stable; urgency=low
 
   * [check-windows-eventlog] add --source-exclude, --message-exclude and

--- a/packaging/rpm/mackerel-check-plugins.spec
+++ b/packaging/rpm/mackerel-check-plugins.spec
@@ -45,6 +45,9 @@ done
 %{__oldtargetdir}/*
 
 %changelog
+* Wed Feb 08 2017 <mackerel-developers@hatena.ne.jp> - 0.9.3-1
+- fix matching for 'Audit Success' and 'Audit Failure' (by mattn)
+
 * Wed Jan 25 2017 <mackerel-developers@hatena.ne.jp> - 0.9.2-1
 - [check-windows-eventlog] add --source-exclude, --message-exclude and --event-id (by mattn, daiksy)
 - [check-windows-eventlog] remove --event-id and add --event-id-pattern, --event-id-exclude (by mattn)


### PR DESCRIPTION
- fix matching for 'Audit Success' and 'Audit Failure' #139