### PR TITLE
Write the file in same directory

### DIFF
--- a/check-log/check-log.go
+++ b/check-log/check-log.go
@@ -356,7 +356,8 @@ func writeBytesToSkip(f string, num int64) error {
 }
 
 func writeFileAtomically(f string, contents []byte) error {
-	tmpf, err := ioutil.TempFile("", "")
+	// MUST be located on same disk partition
+	tmpf, err := ioutil.TempFile(filepath.Dir(f), "tmp")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Temporary file may not locate at same disk-partition, or same filesytem.
When the path of temporary file doesn't locate at same disk-partition,
os.Rename works like copying file.