### PR TITLE
check lower-case driver letters

### DIFF
--- a/check-log/lib/check-log.go
+++ b/check-log/lib/check-log.go
@@ -319,7 +319,7 @@ func (opts *logOpts) match(line string) (bool, []string) {
 	return matched, matches
 }
 
-var stateRe = regexp.MustCompile(`^([A-Z]):[/\\]`)
+var stateRe = regexp.MustCompile(`^([a-zA-Z]):[/\\]`)
 
 func getStateFile(stateDir, f string, args []string) string {
 	return filepath.Join(


### PR DESCRIPTION
When lower-case filename is specified with `-file`, check-log try to make directory `%APPDATA%\temp\check-log\C:`. (`:` is invalid)