### PR TITLE
[check-log]  When specified multiple pattern, perform search that satisfies all conditions

### DIFF
--- a/check-log/lib/check-log.go
+++ b/check-log/lib/check-log.go
@@ -23,7 +23,7 @@ import (
 
 type logOpts struct {
 	LogFile             string   `short:"f" long:"file" value-name:"FILE" description:"Path to log file"`
-	Pattern             []string `short:"p" long:"pattern" required:"true" value-name:"PAT" description:"Pattern to search for. If specified multiple, they are treated as AND condition"`
+	Pattern             []string `short:"p" long:"pattern" required:"true" value-name:"PAT" description:"Pattern to search for. If specified multiple, they will be treated together with the AND operator"`
 	Exclude             string   `short:"E" long:"exclude" value-name:"PAT" description:"Pattern to exclude from matching"`
 	WarnOver            int64    `short:"w" long:"warning-over" description:"Trigger a warning if matched lines is over a number"`
 	CritOver            int64    `short:"c" long:"critical-over" description:"Trigger a critical if matched lines is over a number"`

--- a/check-log/lib/check-log.go
+++ b/check-log/lib/check-log.go
@@ -23,7 +23,7 @@ import (
 
 type logOpts struct {
 	LogFile             string   `short:"f" long:"file" value-name:"FILE" description:"Path to log file"`
-	Pattern             []string `short:"p" long:"pattern" required:"true" value-name:"PAT" description:"Pattern to search for"`
+	Pattern             []string `short:"p" long:"pattern" required:"true" value-name:"PAT" description:"Pattern to search for. If specified multiple, they are treated as AND condition"`
 	Exclude             string   `short:"E" long:"exclude" value-name:"PAT" description:"Pattern to exclude from matching"`
 	WarnOver            int64    `short:"w" long:"warning-over" description:"Trigger a warning if matched lines is over a number"`
 	CritOver            int64    `short:"c" long:"critical-over" description:"Trigger a critical if matched lines is over a number"`

--- a/check-log/lib/check-log.go
+++ b/check-log/lib/check-log.go
@@ -321,17 +321,16 @@ func (opts *logOpts) searchReader(rdr io.Reader) (warnNum, critNum, readBytes in
 }
 
 func (opts *logOpts) match(line string) (bool, []string) {
-	matched := true
 	var matches []string
 	for _, pReg := range opts.patternReg {
-		if matched {
-			eReg := opts.excludeReg
+		eReg := opts.excludeReg
 
-			matches = pReg.FindStringSubmatch(line)
-			matched = len(matches) > 0 && (eReg == nil || !eReg.MatchString(line))
+		matches = pReg.FindStringSubmatch(line)
+		if len(matches) == 0 || (eReg != nil && eReg.MatchString(line)) {
+			return false, nil
 		}
 	}
-	return matched, matches
+	return true, matches
 }
 
 var stateRe = regexp.MustCompile(`^([a-zA-Z]):[/\\]`)

--- a/check-log/lib/check-log.go
+++ b/check-log/lib/check-log.go
@@ -54,13 +54,12 @@ func (opts *logOpts) prepare() error {
 	for _, ptn := range opts.Pattern {
 		if reg, err = regCompileWithCase(ptn, opts.CaseInsensitive); err != nil {
 			return fmt.Errorf("pattern is invalid")
-		} else {
-			opts.patternReg = append(opts.patternReg, reg)
 		}
+		opts.patternReg = append(opts.patternReg, reg)
 	}
 
 	if len(opts.patternReg) > 1 && (opts.WarnLevel > 0 || opts.CritLevel > 0) {
-		return fmt.Errorf("When multiple patterns specified, --warning-level --critical-level can not be used.")
+		return fmt.Errorf("When multiple patterns specified, --warning-level --critical-level can not be used")
 	}
 
 	if opts.Exclude != "" {

--- a/check-log/lib/check-log.go
+++ b/check-log/lib/check-log.go
@@ -59,6 +59,10 @@ func (opts *logOpts) prepare() error {
 		}
 	}
 
+	if len(opts.patternReg) > 1 && (opts.WarnLevel > 0 || opts.CritLevel > 0) {
+		return fmt.Errorf("When multiple patterns specified, --warning-level --critical-level can not be used.")
+	}
+
 	if opts.Exclude != "" {
 		opts.excludeReg, err = regCompileWithCase(opts.Exclude, opts.CaseInsensitive)
 		if err != nil {

--- a/check-log/lib/check-log_test.go
+++ b/check-log/lib/check-log_test.go
@@ -673,4 +673,15 @@ func TestRunMultiplePattern(t *testing.T) {
 		assert.Equal(t, ckr.Message, msg, "something went wrong")
 	}
 	testWithLevel()
+
+	testInvalidPattern := func() {
+		fh.WriteString(l3)
+		ptn3 := "+"
+		params := []string{"-s", dir, "-f", logf, "-p", ptn1, "-p", ptn3}
+		ckr := run(params)
+		assert.Equal(t, checkers.UNKNOWN, ckr.Status, "ckr.Status should be UNKNOWN")
+		msg := "pattern is invalid"
+		assert.Equal(t, ckr.Message, msg, "something went wrong")
+	}
+	testInvalidPattern()
 }

--- a/check-log/lib/check-log_test.go
+++ b/check-log/lib/check-log_test.go
@@ -662,4 +662,15 @@ func TestRunMultiplePattern(t *testing.T) {
 		assert.Equal(t, int64(len(l1)+len(l2)), bytes, "something went wrong")
 	}
 	testAndCondition()
+
+	l3 := "OK\n"
+	testWithLevel := func() {
+		fh.WriteString(l3)
+		params := []string{"-s", dir, "-f", logf, "-p", ptn1, "-p", ptn2, "--warning-level", "12"}
+		ckr := run(params)
+		assert.Equal(t, checkers.UNKNOWN, ckr.Status, "ckr.Status should be UNKNOWN")
+		msg := "When multiple patterns specified, --warning-level --critical-level can not be used."
+		assert.Equal(t, ckr.Message, msg, "something went wrong")
+	}
+	testWithLevel()
 }

--- a/check-log/lib/check-log_test.go
+++ b/check-log/lib/check-log_test.go
@@ -669,7 +669,7 @@ func TestRunMultiplePattern(t *testing.T) {
 		params := []string{"-s", dir, "-f", logf, "-p", ptn1, "-p", ptn2, "--warning-level", "12"}
 		ckr := run(params)
 		assert.Equal(t, checkers.UNKNOWN, ckr.Status, "ckr.Status should be UNKNOWN")
-		msg := "When multiple patterns specified, --warning-level --critical-level can not be used."
+		msg := "When multiple patterns specified, --warning-level --critical-level can not be used"
 		assert.Equal(t, ckr.Message, msg, "something went wrong")
 	}
 	testWithLevel()


### PR DESCRIPTION
Current specification of `check-log` , it is difficult to satisfy `AND` as the log monitoring condition.

This p-r is to make it possible to perform log monitoring that satisfies all the patterns when multiple `--pattern` are specified.