### PR TITLE
Make `make deb` work in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ addons:
     - rpm
     - devscripts
     - debhelper
+    - fakeroot
 install:
 - mkdir -p ~/rpmbuild/{BUILD,BUILDROOT,RPMS,SOURCES,SPECS,SRPMS}
 script:


### PR DESCRIPTION
CI Failure: https://travis-ci.org/mackerelio/go-check-plugins/builds/255560624#L1105-L1109
ref: https://github.com/mackerelio/mackerel-agent/pull/396