### PR TITLE
[nit] add plugin executables pattern in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 !.goxc.json
 !.travis.yml
 /build
+check-*/check-*


### PR DESCRIPTION
Same here as https://github.com/mackerelio/mackerel-agent-plugins/pull/379. Related: #186.