### PR TITLE
Skip IPv6 tests in Travis

### DIFF
--- a/check-tcp/lib/check-tcp_test.go
+++ b/check-tcp/lib/check-tcp_test.go
@@ -263,6 +263,9 @@ func TestHTTPIPv6(t *testing.T) {
 
 	l, err := net.Listen("tcp", "[::1]:0")
 	if err != nil {
+		if os.Getenv("TRAVIS") != "" {
+			t.Skip("Skip: in Travis, ipv6 networking seems not working.")
+		}
 		t.Error(err)
 	}
 	defer l.Close()


### PR DESCRIPTION
TestHTTPIPv6 in check-tcp tests start failing recently: https://travis-ci.org/mackerelio/go-check-plugins/builds
From the error message, maybe ipv6 networking does not work in Travis container. (Even if so, I don't know why it has been working...)

So I'd like to skip this test for now.