### PR TITLE
[check-http] Expose checkhttp.Run due for using check-http as a library

### DIFF
--- a/check-http/lib/check_http.go
+++ b/check-http/lib/check_http.go
@@ -25,7 +25,7 @@ var opts struct {
 
 // Do the plugin
 func Do() {
-	ckr := run(os.Args[1:])
+	ckr := Run(os.Args[1:])
 	ckr.Name = "HTTP"
 	ckr.Exit()
 }
@@ -90,7 +90,8 @@ func parseStatusRanges() ([]statusRange, error) {
 	return statuses, nil
 }
 
-func run(args []string) *checkers.Checker {
+// Run do external monitoring via HTTP
+func Run(args []string) *checkers.Checker {
 	_, err := flags.ParseArgs(&opts, args)
 	if err != nil {
 		os.Exit(1)

--- a/check-http/lib/check_http_test.go
+++ b/check-http/lib/check_http_test.go
@@ -9,13 +9,13 @@ import (
 )
 
 func TestRun(t *testing.T) {
-	ckr := run([]string{"-u", "hoge"})
+	ckr := Run([]string{"-u", "hoge"})
 	assert.Equal(t, ckr.Status, checkers.CRITICAL, "chr.Status should be CRITICAL")
 	assert.Equal(t, ckr.Message, `Get hoge: unsupported protocol scheme ""`, "something went wrong")
 }
 
 func TestNoCheckCertificate(t *testing.T) {
-	ckr := run([]string{"--no-check-certificate", "-u", "hoge"})
+	ckr := Run([]string{"--no-check-certificate", "-u", "hoge"})
 	assert.Equal(t, ckr.Status, checkers.CRITICAL, "chr.Status should be CRITICAL")
 	assert.Equal(t, ckr.Message, `Get hoge: unsupported protocol scheme ""`, "something went wrong")
 }
@@ -64,12 +64,12 @@ func TestStatusRange(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		ckr := run(tt.args)
+		ckr := Run(tt.args)
 		assert.Equal(t, ckr.Status, tt.want, fmt.Sprintf("chr.Status wrong: %v", ckr.Status))
 	}
 }
 
 func TestSourceIP(t *testing.T) {
-	ckr := run([]string{"-u", "hoge", "-i", "1.2.3"})
+	ckr := Run([]string{"-u", "hoge", "-i", "1.2.3"})
 	assert.Equal(t, ckr.Status, checkers.UNKNOWN, "chr.Status should be UNKNOWN")
 }


### PR DESCRIPTION
[go-magi][], yet another external monitoring tool, currently execute check-http command using os/exec package.

Generally speaking, we must pay some costs while calling fork or exec syscalls, and also have to abandon cross-platform features while touching `ProcessState`, even writing in Go.

[go-magi]: https://github.com/aereal/go-magi