### PR TITLE
[check-tcp] add -W option

### DIFF
--- a/check-tcp/README.md
+++ b/check-tcp/README.md
@@ -30,6 +30,8 @@ command = "/path/to/check-tcp -H localhost -p 4224 -w 3 -c 5"
 -c, --critical=            Response time to result in critical status (seconds)
 -E, --escape               Can use \n, \r, \t or \ in send or quit string. Must come before send or quit option. By
                            default, nothing added to send, \r\n added to end of quit
+-W, --err-warning          Set the error level to warning when exiting with unexpected error (default: critical).
+                           In the case of request succeeded, evaluation result of -c option eval takes priority.
 ```
 
 ## Other

--- a/check-tcp/README.md
+++ b/check-tcp/README.md
@@ -30,7 +30,7 @@ command = "/path/to/check-tcp -H localhost -p 4224 -w 3 -c 5"
 -c, --critical=            Response time to result in critical status (seconds)
 -E, --escape               Can use \n, \r, \t or \ in send or quit string. Must come before send or quit option. By
                            default, nothing added to send, \r\n added to end of quit
--W, --error-warning          Set the error level to warning when exiting with unexpected error (default: critical).
+-W, --error-warning        Set the error level to warning when exiting with unexpected error (default: critical).
                            In the case of request succeeded, evaluation result of -c option eval takes priority.
 ```
 

--- a/check-tcp/README.md
+++ b/check-tcp/README.md
@@ -30,7 +30,7 @@ command = "/path/to/check-tcp -H localhost -p 4224 -w 3 -c 5"
 -c, --critical=            Response time to result in critical status (seconds)
 -E, --escape               Can use \n, \r, \t or \ in send or quit string. Must come before send or quit option. By
                            default, nothing added to send, \r\n added to end of quit
--W, --err-warning          Set the error level to warning when exiting with unexpected error (default: critical).
+-W, --error-warning          Set the error level to warning when exiting with unexpected error (default: critical).
                            In the case of request succeeded, evaluation result of -c option eval takes priority.
 ```
 

--- a/check-tcp/lib/check-tcp.go
+++ b/check-tcp/lib/check-tcp.go
@@ -161,7 +161,6 @@ func (opts *tcpOpts) run() *checkers.Checker {
 	if err != nil {
 		return checkers.Unknown(err.Error())
 	}
-
 	// prevent changing output of some commands
 	os.Setenv("LANG", "C")
 	os.Setenv("LC_ALL", "C")

--- a/check-tcp/lib/check-tcp.go
+++ b/check-tcp/lib/check-tcp.go
@@ -24,7 +24,7 @@ type tcpOpts struct {
 	Warning    float64 `short:"w" long:"warning" description:"Response time to result in warning status (seconds)"`
 	Critical   float64 `short:"c" long:"critical" description:"Response time to result in critical status (seconds)"`
 	Escape     bool    `short:"E" long:"escape" description:"Can use \\n, \\r, \\t or \\ in send or quit string. Must come before send or quit option. By default, nothing added to send, \\r\\n added to end of quit"`
-	ErrWarning bool    `short:"W" long:"err-warning" description:"Set the error level to warning when exiting with unexpected error (default: critical). In the case of request succeeded, evaluation result of -c option eval takes priority."`
+	ErrWarning bool    `short:"W" long:"error-warning" description:"Set the error level to warning when exiting with unexpected error (default: critical). In the case of request succeeded, evaluation result of -c option eval takes priority."`
 }
 
 type exchange struct {

--- a/check-tcp/lib/check-tcp.go
+++ b/check-tcp/lib/check-tcp.go
@@ -18,12 +18,13 @@ type tcpOpts struct {
 	Service  string `long:"service" description:"Service name. e.g. ftp, smtp, pop, imap and so on"`
 	Hostname string `short:"H" long:"hostname" description:"Host name or IP Address"`
 	exchange
-	Timeout  float64 `short:"t" long:"timeout" default:"10" description:"Seconds before connection times out"`
-	MaxBytes int     `short:"m" long:"maxbytes" description:"Close connection once more than this number of bytes are received"`
-	Delay    float64 `short:"d" long:"delay" description:"Seconds to wait between sending string and polling for response"`
-	Warning  float64 `short:"w" long:"warning" description:"Response time to result in warning status (seconds)"`
-	Critical float64 `short:"c" long:"critical" description:"Response time to result in critical status (seconds)"`
-	Escape   bool    `short:"E" long:"escape" description:"Can use \\n, \\r, \\t or \\ in send or quit string. Must come before send or quit option. By default, nothing added to send, \\r\\n added to end of quit"`
+	Timeout    float64 `short:"t" long:"timeout" default:"10" description:"Seconds before connection times out"`
+	MaxBytes   int     `short:"m" long:"maxbytes" description:"Close connection once more than this number of bytes are received"`
+	Delay      float64 `short:"d" long:"delay" description:"Seconds to wait between sending string and polling for response"`
+	Warning    float64 `short:"w" long:"warning" description:"Response time to result in warning status (seconds)"`
+	Critical   float64 `short:"c" long:"critical" description:"Response time to result in critical status (seconds)"`
+	Escape     bool    `short:"E" long:"escape" description:"Can use \\n, \\r, \\t or \\ in send or quit string. Must come before send or quit option. By default, nothing added to send, \\r\\n added to end of quit"`
+	ErrWarning bool    `short:"W" long:"err-warning" description:"Set the exit status at error occurrence to WARNING (default is CRITICAL). -c option is not affected by this option."`
 }
 
 type exchange struct {
@@ -160,6 +161,7 @@ func (opts *tcpOpts) run() *checkers.Checker {
 	if err != nil {
 		return checkers.Unknown(err.Error())
 	}
+
 	// prevent changing output of some commands
 	os.Setenv("LANG", "C")
 	os.Setenv("LC_ALL", "C")
@@ -178,6 +180,9 @@ func (opts *tcpOpts) run() *checkers.Checker {
 
 	conn, err := dial(proto, addr, opts.SSL, opts.NoCheckCertificate, timeout)
 	if err != nil {
+		if opts.ErrWarning {
+			return checkers.Warning(err.Error())
+		}
 		return checkers.Critical(err.Error())
 	}
 	defer conn.Close()
@@ -185,6 +190,9 @@ func (opts *tcpOpts) run() *checkers.Checker {
 	if opts.Send != "" {
 		err := write(conn, []byte(opts.Send), timeout)
 		if err != nil {
+			if opts.ErrWarning {
+				return checkers.Warning(err.Error())
+			}
 			return checkers.Critical(err.Error())
 		}
 	}
@@ -193,10 +201,16 @@ func (opts *tcpOpts) run() *checkers.Checker {
 	if opts.expectReg != nil {
 		buf, err := slurp(conn, opts.MaxBytes, timeout)
 		if err != nil {
+			if opts.ErrWarning {
+				return checkers.Warning(err.Error())
+			}
 			return checkers.Critical(err.Error())
 		}
 		res = string(buf)
 		if !opts.expectReg.MatchString(res) {
+			if opts.ErrWarning {
+				return checkers.Warning("Unexpected response from host/socket: " + res)
+			}
 			return checkers.Critical("Unexpected response from host/socket: " + res)
 		}
 	}
@@ -204,6 +218,9 @@ func (opts *tcpOpts) run() *checkers.Checker {
 	if opts.Quit != "" {
 		err := write(conn, []byte(opts.Quit), timeout)
 		if err != nil {
+			if opts.ErrWarning {
+				return checkers.Warning(err.Error())
+			}
 			return checkers.Critical(err.Error())
 		}
 	}

--- a/check-tcp/lib/check-tcp.go
+++ b/check-tcp/lib/check-tcp.go
@@ -24,7 +24,7 @@ type tcpOpts struct {
 	Warning    float64 `short:"w" long:"warning" description:"Response time to result in warning status (seconds)"`
 	Critical   float64 `short:"c" long:"critical" description:"Response time to result in critical status (seconds)"`
 	Escape     bool    `short:"E" long:"escape" description:"Can use \\n, \\r, \\t or \\ in send or quit string. Must come before send or quit option. By default, nothing added to send, \\r\\n added to end of quit"`
-	ErrWarning bool    `short:"W" long:"err-warning" description:"Set the exit status at error occurrence to WARNING (default is CRITICAL). -c option is not affected by this option."`
+	ErrWarning bool    `short:"W" long:"err-warning" description:"Set the error level to warning when exiting with unexpected error (default: critical). In the case of request succeeded, evaluation result of -c option eval takes priority."`
 }
 
 type exchange struct {

--- a/check-tcp/lib/check-tcp_test.go
+++ b/check-tcp/lib/check-tcp_test.go
@@ -149,6 +149,16 @@ func TestHTTP(t *testing.T) {
 	}
 	testOk()
 
+	testOkWithErrWarn := func() {
+		opts, err := parseArgs([]string{"-H", host, "-p", port, "--send", `GET / HTTP/1.0\r\n\r\n`, "-E", "-e", "OKOK", "-W"})
+		assert.Equal(t, nil, err, "no errors")
+		ckr := opts.run()
+		fmt.Println(ckr)
+		assert.Equal(t, checkers.OK, ckr.Status, "should be OK")
+		assert.Regexp(t, `seconds response time on`, ckr.Message, "Unexpected response")
+	}
+	testOkWithErrWarn()
+
 	testUnexpected := func() {
 		opts, err := parseArgs(
 			[]string{"-H", host, "-p", port, "--send", `GET / HTTP/1.0\r\n\r\n`, "-E", "-e", "OKOKOK"})
@@ -158,6 +168,16 @@ func TestHTTP(t *testing.T) {
 		assert.Regexp(t, `Unexpected response from`, ckr.Message, "Unexpected response")
 	}
 	testUnexpected()
+
+	testUnexpectedWithErrWarn := func() {
+		opts, err := parseArgs(
+			[]string{"-H", host, "-p", port, "--send", `GET / HTTP/1.0\r\n\r\n`, "-E", "-e", "OKOKOK", "-W"})
+		assert.Equal(t, nil, err, "no errors")
+		ckr := opts.run()
+		assert.Equal(t, checkers.WARNING, ckr.Status, "should be Warning")
+		assert.Regexp(t, `Unexpected response from`, ckr.Message, "Unexpected response")
+	}
+	testUnexpectedWithErrWarn()
 
 	testOverWarn := func() {
 		opts, err := parseArgs(
@@ -169,6 +189,16 @@ func TestHTTP(t *testing.T) {
 	}
 	testOverWarn()
 
+	testOverWarnWithErrWarn := func() {
+		opts, err := parseArgs(
+			[]string{"-H", host, "-p", port, "--send", `GET / HTTP/1.0\r\n\r\n`, "-E", "-e", "OKOK", "-w", "0.1", "-W"})
+		assert.Equal(t, nil, err, "no errors")
+		ckr := opts.run()
+		assert.Equal(t, checkers.WARNING, ckr.Status, "should be Warning")
+		assert.Regexp(t, `seconds response time on`, ckr.Message, "Unexpected response")
+	}
+	testOverWarnWithErrWarn()
+
 	testOverCrit := func() {
 		opts, err := parseArgs(
 			[]string{"-H", host, "-p", port, "--send", "GET / HTTP/1.0\r\n\r\n", "-e", "OKOK", "-c", "0.1"})
@@ -178,6 +208,16 @@ func TestHTTP(t *testing.T) {
 		assert.Regexp(t, `seconds response time on`, ckr.Message, "Unexpected response")
 	}
 	testOverCrit()
+
+	testOverCritWithErrWarn := func() {
+		opts, err := parseArgs(
+			[]string{"-H", host, "-p", port, "--send", "GET / HTTP/1.0\r\n\r\n", "-e", "OKOK", "-c", "0.1", "-W"})
+		assert.Equal(t, nil, err, "no errors")
+		ckr := opts.run()
+		assert.Equal(t, checkers.CRITICAL, ckr.Status, "should be Critical")
+		assert.Regexp(t, `seconds response time on`, ckr.Message, "Unexpected response")
+	}
+	testOverCritWithErrWarn()
 }
 
 func TestUnixDomainSocket(t *testing.T) {


### PR DESCRIPTION
I Added -W option in order to suppress CRITICAL when error occurred.

-W sets the exit status at error occurrence to WARNING.

In the case of request succeeded, evaluation result of -c option eval takes priority.