### PR TITLE
[nit] Use Go 1.9.x on TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 go:
-- 1.9
+- 1.9.x
 env:
   global:
   - PATH=~/gopath/bin:$PATH


### PR DESCRIPTION
Upgrade the Go version to the latest.