### PR TITLE
[check-log]improve skip bytes when file size is zero

### DIFF
--- a/check-log/lib/check-log.go
+++ b/check-log/lib/check-log.go
@@ -235,9 +235,10 @@ func (opts *logOpts) searchLog(logFile string) (int64, int64, string, error) {
 		return 0, 0, "", err
 	}
 
-	_, err = os.Stat(stateFile)
-	if !opts.NoState && !opts.CheckFirst && os.IsNotExist(err) {
-		skipBytes = stat.Size()
+	if !opts.NoState && !opts.CheckFirst {
+		if _, err = os.Stat(stateFile); os.IsNotExist(err) {
+			skipBytes = stat.Size()
+		}
 	}
 
 	rotated := false

--- a/check-log/lib/check-log.go
+++ b/check-log/lib/check-log.go
@@ -235,7 +235,8 @@ func (opts *logOpts) searchLog(logFile string) (int64, int64, string, error) {
 		return 0, 0, "", err
 	}
 
-	if !opts.NoState && !opts.CheckFirst && skipBytes == 0 {
+	_, err = os.Stat(stateFile)
+	if !opts.NoState && !opts.CheckFirst && os.IsNotExist(err) {
 		skipBytes = stat.Size()
 	}
 

--- a/check-log/lib/check-log_test.go
+++ b/check-log/lib/check-log_test.go
@@ -99,9 +99,9 @@ func TestRun(t *testing.T) {
 		fh.WriteString(lFirst)
 		w, c, errLines, err := opts.searchLog(logf)
 		assert.Equal(t, err, nil, "err should be nil")
-		assert.Equal(t, int64(0), w, "something went wrong")
-		assert.Equal(t, int64(0), c, "something went wrong")
-		assert.Equal(t, "", errLines, "something went wrong")
+		assert.Equal(t, int64(2), w, "something went wrong")
+		assert.Equal(t, int64(2), c, "something went wrong")
+		assert.Equal(t, lFirst, errLines, "something went wrong")
 
 		bytes, _ = getBytesToSkip(stateFile)
 		assert.Equal(t, int64(len(lFirst)), bytes, "something went wrong")


### PR DESCRIPTION
- If the file size is zero, the following error will be ignored.