### PR TITLE
Fix duplicated output of usage with --help argument

### DIFF
--- a/check-cert-file/lib/check-cert-file.go
+++ b/check-cert-file/lib/check-cert-file.go
@@ -4,11 +4,12 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
-	"github.com/jessevdk/go-flags"
-	"github.com/mackerelio/checkers"
 	"io/ioutil"
 	"os"
 	"time"
+
+	"github.com/jessevdk/go-flags"
+	"github.com/mackerelio/checkers"
 )
 
 type certOpts struct {
@@ -29,7 +30,6 @@ func checkCertExpiration() *checkers.Checker {
 	psr := flags.NewParser(&opts, flags.Default)
 	_, err := psr.Parse()
 	if err != nil {
-		psr.WriteHelp(os.Stdout)
 		os.Exit(1)
 	}
 

--- a/check-procs/lib/check_procs.go
+++ b/check-procs/lib/check_procs.go
@@ -61,7 +61,7 @@ func Do() {
 func run(args []string) *checkers.Checker {
 	_, err := flags.ParseArgs(&opts, args)
 	if err != nil {
-		return checkers.NewChecker(checkers.UNKNOWN, err.Error())
+		os.Exit(1)
 	}
 
 	// for backward compatibility


### PR DESCRIPTION
This pull request fixes the problem `check-procs --help` and `check-cert-file --help` outputs the command usage twice.

```sh
 % for f in check-*; do (cd $f >/dev/null && test $(go run main.go --help 2>&1 | grep 'Application Options' | wc -l) -gt 1 && echo $f); done
check-cert-file/
check-procs/
```