### PR TITLE
[check-windows-eventlog] fix README - Some of the listed EVENTTYPEs can not be detected as alerts

### DIFF
--- a/check-windows-eventlog/README.md
+++ b/check-windows-eventlog/README.md
@@ -21,13 +21,13 @@ command = "/path/to/check-windows-eventlog --log=LOGTYPE --type=EVENTTYPE --sour
 
 * Error
 * Audit Failure
+* Warning
 
 The following EVENTTYPE can not be detected as an alert.
 
 * Success
 * Audit Success
 * Information
-* Warning
 
 ## Tutorial
 

--- a/check-windows-eventlog/README.md
+++ b/check-windows-eventlog/README.md
@@ -19,9 +19,12 @@ command = "/path/to/check-windows-eventlog --log=LOGTYPE --type=EVENTTYPE --sour
 
 ### EVENTTYPE
 
-* Success
 * Error
 * Audit Failure
+
+The following EVENTTYPE can not be detected as an alert.
+
+* Success
 * Audit Success
 * Information
 * Warning


### PR DESCRIPTION
The following EVENTTYPE can not be detected as an alert.

- Success
- Audit Success
- Information


I think that it is better to mention this in the README.