### PR TITLE
Add feature use ntp server

### DIFF
--- a/check-ntpoffset/lib/check-ntpoffset.go
+++ b/check-ntpoffset/lib/check-ntpoffset.go
@@ -153,6 +153,7 @@ func getNTPOffsetFromNTPServers(ntpServers string) (offset float64, err error) {
 
 	select {
 	case <-time.After(time.Duration(ntpTimeout) * time.Second):
+		// return error only when all NTPServers are failed
 		return 0.0, fmt.Errorf("NTP offset cannot get from %q", ntpServers)
 	case offset = <-resultChan:
 		return offset, nil


### PR DESCRIPTION
In our usecase, compare localtime to ntp server is better (just like nagios plugins).

I think compare localtime to ntp server is more direct(and have some benefit) way than check via time-sync daemon.