### PR TITLE
[check-http] Set Host header via req.Host

### DIFF
--- a/check-http/lib/check_http.go
+++ b/check-http/lib/check_http.go
@@ -25,7 +25,7 @@ type checkHTTPOpts struct {
 	Statuses           []string `short:"s" long:"status" description:"mapping of HTTP status"`
 	NoCheckCertificate bool     `long:"no-check-certificate" description:"Do not check certificate"`
 	SourceIP           string   `short:"i" long:"source-ip" description:"source IP address"`
-	Headers            []string `short:"H" description:"Host name for servers using host headers"`
+	Headers            []string `short:"H" description:"HTTP request headers"`
 	Regexp             string   `short:"p" long:"pattern" description:"Expected pattern in the content"`
 }
 
@@ -145,10 +145,18 @@ func Run(args []string) *checkers.Checker {
 	}
 
 	if len(opts.Headers) != 0 {
-		req.Header, err = parseHeader(&opts)
+		header, err := parseHeader(&opts)
 		if err != nil {
 			return checkers.Unknown(err.Error())
 		}
+
+		// Host header must be set via req.Host
+		if host := header.Get("Host"); len(host) != 0 {
+			req.Host = host
+			header.Del("Host")
+		}
+
+		req.Header = header
 	}
 
 	stTime := time.Now()

--- a/check-http/lib/check_http_test.go
+++ b/check-http/lib/check_http_test.go
@@ -77,7 +77,22 @@ func TestSourceIP(t *testing.T) {
 }
 
 func TestHost(t *testing.T) {
-	ckr := Run([]string{"-H", `"Host: mackerel.io"`, "-H", `"Accept-Encoding: gzip"`, "-u", "https://mackerel.io"})
+	testHost := "mackerel.io"
+	testHeader := "test"
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, testHost, r.Host)
+		header := r.Header
+		assert.Equal(t, testHeader, header.Get("TestHeader"))
+	}))
+	defer ts.Close()
+
+	ckr := Run([]string{
+		"-H", fmt.Sprintf("Host: %s", testHost),
+		"-H", fmt.Sprintf("TestHeader: %s", testHeader),
+		"-u", ts.URL,
+	})
+
 	assert.Equal(t, ckr.Status, checkers.OK, "ckr.Status should be OK")
 }
 


### PR DESCRIPTION
net/http uses `req.Host` for Host header, not `req.Headers`.
`req.Host` is set to `req.URL.Host` by default, so `Host` in `req.Headers` is ignored.

In this commit, set `req.Host` from parsed header if specified.

> For client requests, certain headers such as Content-Length
> and Connection are automatically written when needed and
> values in Header may be ignored. See the documentation
> for the Request.Write method.
>
> https://golang.org/pkg/net/http/#Request