### PR TITLE
Add check-smtp

### DIFF
--- a/check-smtp/README.md
+++ b/check-smtp/README.md
@@ -22,7 +22,7 @@ command = "/path/to/check-smtp -H smtp.example.com -p 25 -w 3 -c 5 -t 10"
   -A, --authmech=     SMTP AUTH Authentication Mechanisms(only PLAIN supported)
   -U, --authuser=     SMTP AUTH username
   -P, --authpassword= SMTP AUTH password
-  -w, --warning=      Warning threshold (sec) (default: 3)
-  -c, --critical=     Critical threshold (sec) (default: 5)
+  -w, --warning=      Warning threshold (sec)
+  -c, --critical=     Critical threshold (sec)
   -t, --timeout=      Timeout (sec) (default: 10)
 ```

--- a/check-smtp/README.md
+++ b/check-smtp/README.md
@@ -1,0 +1,28 @@
+# check-smtp
+
+## Description
+
+Check for SMTP connection.
+
+## Setting
+
+```
+[plugin.checks.smtp]
+command = "/path/to/check-smtp -H smtp.example.com -p 25 -w 3 -c 5 -t 10"
+```
+
+## Options
+
+```
+  -H, --host=         Hostname (default: localhost)
+  -p, --port=         Port (default: 25)
+  -F, --fqdn=         FQDN used for HELO
+  -s, --smtps         Use SMTP over TLS
+  -S, --starttls      Use STARTTLS
+  -A, --authmech=     SMTP AUTH Authentication Mechanisms(only PLAIN supported)
+  -U, --authuser=     SMTP AUTH username
+  -P, --authpassword= SMTP AUTH password
+  -w, --warning=      Warning threshold (sec) (default: 3)
+  -c, --critical=     Critical threshold (sec) (default: 5)
+  -t, --timeout=      Timeout (sec) (default: 10)
+```

--- a/check-smtp/lib/check-smtp.go
+++ b/check-smtp/lib/check-smtp.go
@@ -1,16 +1,11 @@
 package checksmtp
 
 import (
-	"os"
-
-	"net/smtp"
-
-	"fmt"
-
 	"crypto/tls"
-
+	"fmt"
 	"net"
-
+	"net/smtp"
+	"os"
 	"time"
 
 	"github.com/jessevdk/go-flags"

--- a/check-smtp/lib/check-smtp.go
+++ b/check-smtp/lib/check-smtp.go
@@ -26,8 +26,8 @@ var opts struct {
 	Auth     string  `short:"A" long:"authmech" description:"SMTP AUTH Authentication Mechanisms (only PLAIN supported)"`
 	User     string  `short:"U" long:"authuser" description:"SMTP AUTH username"`
 	Password string  `short:"P" long:"authpassword" description:"SMTP AUTH password"`
-	Warning  float64 `short:"w" long:"warning" default:"3" description:"Warning threshold (sec)"`
-	Critical float64 `short:"c" long:"critical" default:"5" description:"Critical threshold (sec)"`
+	Warning  float64 `short:"w" long:"warning" description:"Warning threshold (sec)"`
+	Critical float64 `short:"c" long:"critical" description:"Critical threshold (sec)"`
 	Timeout  int     `short:"t" long:"timeout" default:"10" description:"Timeout (sec)"`
 }
 
@@ -50,6 +50,10 @@ func run(args []string) *checkers.Checker {
 	_, err := flags.ParseArgs(&opts, args)
 	if err != nil {
 		os.Exit(1)
+	}
+
+	if opts.Warning == 0 && opts.Critical == 0 {
+		return checkers.Unknown("require threshold option (warning or critical)")
 	}
 
 	if opts.Auth != "" && opts.Auth != "PLAIN" {
@@ -110,9 +114,9 @@ func run(args []string) *checkers.Checker {
 
 	msg := fmt.Sprintf("%.3f seconds response time", elapsed.Seconds())
 
-	if elapsed.Seconds() > opts.Critical {
+	if opts.Critical != 0 && elapsed.Seconds() > opts.Critical {
 		return checkers.Critical(msg)
-	} else if elapsed.Seconds() > opts.Warning {
+	} else if opts.Warning != 0 && elapsed.Seconds() > opts.Warning {
 		return checkers.Warning(msg)
 	} else {
 		return checkers.Ok(msg)

--- a/check-smtp/lib/check-smtp.go
+++ b/check-smtp/lib/check-smtp.go
@@ -17,7 +17,7 @@ import (
 	"github.com/mackerelio/checkers"
 )
 
-var opts struct {
+type options struct {
 	Host     string  `short:"H" long:"host" default:"localhost" description:"Hostname"`
 	Port     string  `short:"p" long:"port" default:"25" description:"Port"`
 	FQDN     string  `short:"F" long:"fqdn" description:"FQDN used for HELO"`
@@ -43,10 +43,11 @@ func makeConn(host, port string, timeout int, isSMTPS bool, tlsConfig *tls.Confi
 	if isSMTPS {
 		return tls.DialWithDialer(&d, "tcp", fmt.Sprintf("%s:%s", host, port), tlsConfig)
 	}
-	return d.Dial("tcp", fmt.Sprintf("%s:%s", opts.Host, opts.Port))
+	return d.Dial("tcp", fmt.Sprintf("%s:%s", host, port))
 }
 
 func run(args []string) *checkers.Checker {
+	var opts options
 	_, err := flags.ParseArgs(&opts, args)
 	if err != nil {
 		os.Exit(1)

--- a/check-smtp/lib/check-smtp.go
+++ b/check-smtp/lib/check-smtp.go
@@ -1,0 +1,120 @@
+package checksmtp
+
+import (
+	"os"
+
+	"net/smtp"
+
+	"fmt"
+
+	"crypto/tls"
+
+	"net"
+
+	"time"
+
+	"github.com/jessevdk/go-flags"
+	"github.com/mackerelio/checkers"
+)
+
+var opts struct {
+	Host     string  `short:"H" long:"host" default:"localhost" description:"Hostname"`
+	Port     string  `short:"p" long:"port" default:"25" description:"Port"`
+	FQDN     string  `short:"F" long:"fqdn" description:"FQDN used for HELO"`
+	SMTPS    bool    `short:"s" long:"smtps" description:"Use SMTP over TLS"`
+	StartTLS bool    `short:"S" long:"starttls" description:"Use STARTTLS"`
+	Auth     string  `short:"A" long:"authmech" description:"SMTP AUTH Authentication Mechanisms (only PLAIN supported)"`
+	User     string  `short:"U" long:"authuser" description:"SMTP AUTH username"`
+	Password string  `short:"P" long:"authpassword" description:"SMTP AUTH password"`
+	Warning  float64 `short:"w" long:"warning" default:"3" description:"Warning threshold (sec)"`
+	Critical float64 `short:"c" long:"critical" default:"5" description:"Critical threshold (sec)"`
+	Timeout  int     `short:"t" long:"timeout" default:"10" description:"Timeout (sec)"`
+}
+
+// Do the plugin
+func Do() {
+	ckr := run(os.Args[1:])
+	ckr.Name = "SMTP"
+	ckr.Exit()
+}
+
+func makeConn(host, port string, timeout int, isSMTPS bool, tlsConfig *tls.Config) (net.Conn, error) {
+	d := net.Dialer{Timeout: time.Duration(timeout) * time.Second}
+	if isSMTPS {
+		return tls.DialWithDialer(&d, "tcp", fmt.Sprintf("%s:%s", host, port), tlsConfig)
+	}
+	return d.Dial("tcp", fmt.Sprintf("%s:%s", opts.Host, opts.Port))
+}
+
+func run(args []string) *checkers.Checker {
+	_, err := flags.ParseArgs(&opts, args)
+	if err != nil {
+		os.Exit(1)
+	}
+
+	if opts.Auth != "" && opts.Auth != "PLAIN" {
+		return checkers.Unknown("invalid SMTP AUTH Authentication Mechanisms (only PLAIN supported)")
+	}
+
+	fqdn := opts.FQDN
+	if fqdn == "" {
+		localHostName, err := os.Hostname()
+		if err != nil {
+			return checkers.Unknown(err.Error())
+		}
+		fqdn = localHostName
+	}
+
+	tlsConfig := &tls.Config{
+		InsecureSkipVerify: true,
+		ServerName:         opts.Host,
+	}
+
+	conn, err := makeConn(opts.Host, opts.Port, opts.Timeout, opts.SMTPS, tlsConfig)
+	if err != nil {
+		return checkers.Critical(err.Error())
+	}
+
+	stTime := time.Now()
+
+	c, err := smtp.NewClient(conn, opts.Host)
+	if err != nil {
+		return checkers.Critical(err.Error())
+	}
+	defer c.Quit()
+
+	if err := c.Hello(fqdn); err != nil {
+		return checkers.Critical(err.Error())
+	}
+
+	if opts.StartTLS {
+		if err := c.StartTLS(tlsConfig); err != nil {
+			return checkers.Critical(err.Error())
+		}
+	}
+
+	if opts.Auth == "PLAIN" {
+		auth := smtp.PlainAuth("", opts.User, opts.Password, opts.Host)
+		if err := c.Auth(auth); err != nil {
+			return checkers.Critical(err.Error())
+		}
+	}
+
+	if err := c.Mail(""); err != nil {
+		c.Reset()
+		return checkers.Critical(err.Error())
+	}
+	c.Reset()
+
+	elapsed := time.Since(stTime)
+
+	msg := fmt.Sprintf("%.3f seconds response time", elapsed.Seconds())
+
+	if elapsed.Seconds() > opts.Critical {
+		return checkers.Critical(msg)
+	} else if elapsed.Seconds() > opts.Warning {
+		return checkers.Warning(msg)
+	} else {
+		return checkers.Ok(msg)
+	}
+}

--- a/check-smtp/lib/check-smtp.go
+++ b/check-smtp/lib/check-smtp.go
@@ -114,7 +114,7 @@ func run(args []string) *checkers.Checker {
 		return checkers.Critical(msg)
 	} else if opts.Warning != 0 && elapsed.Seconds() > opts.Warning {
 		return checkers.Warning(msg)
-	} else {
-		return checkers.Ok(msg)
 	}
+
+	return checkers.Ok(msg)
 }

--- a/check-smtp/lib/check-smtp_test.go
+++ b/check-smtp/lib/check-smtp_test.go
@@ -84,6 +84,7 @@ func TestSMTP_Default(t *testing.T) {
 		{
 			name:      "timeout",
 			argv:      []string{"--timeout", "-1"},
+			delay:     1,
 			responses: responseDefault,
 			expected:  "CRITICAL",
 		},
@@ -101,7 +102,11 @@ func TestSMTP_Default(t *testing.T) {
 				responses: c.responses,
 				delay:     c.delay,
 			}
-			go s.runServe()
+			go func() {
+				if err := s.runServe(); err != nil {
+					t.Fatal(err.Error())
+				}
+			}()
 			port := strings.Split(ln.Addr().String(), ":")[1]
 			argv := []string{"--host", "127.0.0.1", "--port", port}
 			argv = append(argv, c.argv...)

--- a/check-smtp/lib/check-smtp_test.go
+++ b/check-smtp/lib/check-smtp_test.go
@@ -64,14 +64,14 @@ func TestSMTP_Default(t *testing.T) {
 		{
 			name:      "warning",
 			argv:      []string{"--warning", "1"},
-			delay:     1,
+			delay:     2,
 			responses: responseDefault,
 			expected:  "WARNING",
 		},
 		{
 			name:      "critical",
 			argv:      []string{"--critical", "1"},
-			delay:     1,
+			delay:     2,
 			responses: responseDefault,
 			expected:  "CRITICAL",
 		},

--- a/check-smtp/lib/check-smtp_test.go
+++ b/check-smtp/lib/check-smtp_test.go
@@ -62,12 +62,6 @@ func TestSMTP_Default(t *testing.T) {
 		responses []string
 	}{
 		{
-			name:      "default",
-			argv:      []string{},
-			responses: responseDefault,
-			expected:  "OK",
-		},
-		{
 			name:      "warning",
 			argv:      []string{"--warning", "1"},
 			delay:     1,
@@ -83,7 +77,7 @@ func TestSMTP_Default(t *testing.T) {
 		},
 		{
 			name:      "timeout",
-			argv:      []string{"--timeout", "-1"},
+			argv:      []string{"--critical", "1", "--timeout", "-1"},
 			delay:     1,
 			responses: responseDefault,
 			expected:  "CRITICAL",
@@ -115,5 +109,12 @@ func TestSMTP_Default(t *testing.T) {
 				t.Errorf("%s: %s", ckr.Status.String(), ckr.Message)
 			}
 		})
+	}
+}
+
+func TestSMTP_NoThresholdOptions(t *testing.T) {
+	ckr := run([]string{})
+	if ckr.Status.String() != "UNKNOWN" {
+		t.Errorf("expected UNKNOWN to eq %s", ckr.Status.String())
 	}
 }

--- a/check-smtp/lib/check-smtp_test.go
+++ b/check-smtp/lib/check-smtp_test.go
@@ -1,0 +1,114 @@
+package checksmtp
+
+import (
+	"net"
+	"testing"
+	"time"
+
+	"net/textproto"
+	"strings"
+)
+
+var responseDefault = []string{
+	"220 mail.example.com ESMTP unknown",
+	"250 mail.example.com",
+	"250 OK",
+	"250 OK",
+	"221 Bye",
+}
+
+type mockSMTPServer struct {
+	listener  net.Listener
+	delay     int
+	responses []string
+}
+
+func (m *mockSMTPServer) runServe() error {
+	doneCh := make(chan struct{})
+	errCh := make(chan error)
+	go func() {
+		time.Sleep(time.Duration(m.delay) * time.Second)
+
+		conn, err := m.listener.Accept()
+		if err != nil {
+			errCh <- err
+			return
+		}
+		tc := textproto.NewConn(conn)
+
+		for _, res := range m.responses {
+			if err := tc.PrintfLine(res); err != nil {
+				errCh <- err
+				return
+			}
+		}
+		doneCh <- struct{}{}
+	}()
+
+	select {
+	case <-doneCh:
+		return nil
+	case err := <-errCh:
+		return err
+	}
+}
+
+func TestSMTP_Default(t *testing.T) {
+	var cases = []struct {
+		name      string
+		argv      []string
+		delay     int
+		expected  string
+		responses []string
+	}{
+		{
+			name:      "default",
+			argv:      []string{},
+			responses: responseDefault,
+			expected:  "OK",
+		},
+		{
+			name:      "warning",
+			argv:      []string{"--warning", "1"},
+			delay:     1,
+			responses: responseDefault,
+			expected:  "WARNING",
+		},
+		{
+			name:      "critical",
+			argv:      []string{"--critical", "1"},
+			delay:     1,
+			responses: responseDefault,
+			expected:  "CRITICAL",
+		},
+		{
+			name:      "timeout",
+			argv:      []string{"--timeout", "-1"},
+			responses: responseDefault,
+			expected:  "CRITICAL",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			ln, err := net.Listen("tcp", "127.0.0.1:0")
+			defer ln.Close()
+			if err != nil {
+				t.Fatal(err.Error())
+			}
+			s := mockSMTPServer{
+				listener:  ln,
+				responses: c.responses,
+				delay:     c.delay,
+			}
+			go s.runServe()
+			port := strings.Split(ln.Addr().String(), ":")[1]
+			argv := []string{"--host", "127.0.0.1", "--port", port}
+			argv = append(argv, c.argv...)
+			ckr := run(argv)
+			if ckr.Status.String() != c.expected {
+				t.Errorf("%s: %s", ckr.Status.String(), ckr.Message)
+			}
+		})
+	}
+}

--- a/check-smtp/main.go
+++ b/check-smtp/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/mackerelio/go-check-plugins/check-smtp/lib"
+
+func main() {
+	checksmtp.Do()
+}


### PR DESCRIPTION
This plugin can be used check behave for smtp server.
Plugin sends following commands in basis of SMTP Protocol.

- `HELO/EHLO`
- `STARTTLS` (optional)
- `AUTH` (optional, only `PLAIN` supported)
- `MAIL`
- `RSET`
- `QUIT`
