### PR TITLE
[check-http] Add --max-redirects option

### DIFF
--- a/check-http/lib/check_http_test.go
+++ b/check-http/lib/check_http_test.go
@@ -133,3 +133,39 @@ func TestExpectedContent(t *testing.T) {
 		assert.Equal(t, ckr.Status, tc.status, "#%d: Status should be %s", i, tc.status)
 	}
 }
+
+func TestMaxRedirects(t *testing.T) {
+	redirectedPath := "/redirected"
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != redirectedPath {
+			http.Redirect(w, r, "/redirected", 301)
+		}
+	}))
+	defer ts.Close()
+
+	testCases := []struct {
+		args []string
+		want checkers.Status
+	}{
+		{
+			args: []string{"-s", "301=ok", "-s", "100-300=warning", "-s", "302-599=warning",
+				"-u", ts.URL, "--max-redirects", "0"},
+			want: checkers.OK,
+		},
+		{
+			args: []string{"-s", "200=ok", "-s", "100-199=warning", "-s", "201-599=warning",
+				"-u", ts.URL, "--max-redirects", "1"},
+			want: checkers.OK,
+		},
+		{
+			args: []string{"-s", "200=ok", "-s", "100-199=warning", "-s", "201-599=warning",
+				"-u", ts.URL},
+			want: checkers.OK,
+		},
+	}
+
+	for i, tc := range testCases {
+		ckr := Run(tc.args)
+		assert.Equal(t, ckr.Status, tc.want, "#%d: Status should be %s", i, tc.want)
+	}
+}

--- a/check-http/lib/check_http_test.go
+++ b/check-http/lib/check_http_test.go
@@ -138,7 +138,7 @@ func TestMaxRedirects(t *testing.T) {
 	redirectedPath := "/redirected"
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != redirectedPath {
-			http.Redirect(w, r, "/redirected", 301)
+			http.Redirect(w, r, redirectedPath, 301)
 		}
 	}))
 	defer ts.Close()


### PR DESCRIPTION
`check-http` cannot check redirects currently since [`http.Client` follow redirects by default](https://golang.org/src/net/http/client.go#L728). 

In this PR, I added `--max-redirects` option (like `--max-redirs` in curl or `--max-redirect` in wget) by setting `client.checkRedirect`.

## Example

 ```console
$ ./mackerel-check http --help
Usage:
  mackerel-check [OPTIONS]

Application Options:
  -u, --url=                  A URL to connect to
  -s, --status=               mapping of HTTP status
      --no-check-certificate  Do not check certificate
  -i, --source-ip=            source IP address
  -H=                         HTTP request headers
  -p, --pattern=              Expected pattern in the content
      --max-redirects=        Maximum number of redirects followed (default: 10)

Help Options:
  -h, --help                  Show this help message

$ ./mackerel-check http --max-redirects=1 -u http://mackerel.io/
HTTP OK: HTTP/1.1 200 OK - 35343 bytes in 5.142627 second response time

$ ./mackerel-check http --max-redirects=0 -u http://mackerel.io/
HTTP OK: HTTP/1.1 301 Moved Permanently - 178 bytes in 0.008557 second response time
```