### PR TITLE
[check-log] Jsonize status file

### DIFF
--- a/check-log/lib/check-log.go
+++ b/check-log/lib/check-log.go
@@ -384,7 +384,7 @@ func getBytesToSkip(f string) (int64, error) {
 		return state.SkipBytes, err
 	}
 	// Fallback to read old style status file
-	// for backward compability.
+	// for backward compatibility.
 	// Once saved as new style file, the following will be unreachable.
 	oldf := strings.TrimSuffix(f, ".json")
 	return getBytesToSkipOld(oldf)

--- a/check-log/lib/check-log_test.go
+++ b/check-log/lib/check-log_test.go
@@ -35,7 +35,7 @@ func TestSaveState(t *testing.T) {
 }
 
 func TestGetBytesToSkip(t *testing.T) {
-	// fallback testing for backward compability
+	// fallback testing for backward compatibility
 	oldf := ".tmp/fuga/piyo"
 	newf := ".tmp/fuga/piyo.json"
 	state := &state{SkipBytes: 15}

--- a/check-log/lib/check-log_test.go
+++ b/check-log/lib/check-log_test.go
@@ -15,23 +15,42 @@ import (
 
 func TestGetStateFile(t *testing.T) {
 	sPath := getStateFile("/var/lib", "C:/Windows/hoge", []string{})
-	assert.Equal(t, "/var/lib/C/Windows/hoge-d41d8cd98f00b204e9800998ecf8427e", filepath.ToSlash(sPath), "drive letter should be cared")
+	assert.Equal(t, "/var/lib/C/Windows/hoge-d41d8cd98f00b204e9800998ecf8427e.json", filepath.ToSlash(sPath), "drive letter should be cared")
 
 	sPath = getStateFile("/var/lib", "/linux/hoge", []string{})
-	assert.Equal(t, "/var/lib/linux/hoge-d41d8cd98f00b204e9800998ecf8427e", filepath.ToSlash(sPath), "arguments should be cared")
+	assert.Equal(t, "/var/lib/linux/hoge-d41d8cd98f00b204e9800998ecf8427e.json", filepath.ToSlash(sPath), "arguments should be cared")
 
 	sPath = getStateFile("/var/lib", "/linux/hoge", []string{"aa", "BB"})
-	assert.Equal(t, "/var/lib/linux/hoge-c508092e97c59149a8644827e066ca83", filepath.ToSlash(sPath), "arguments should be cared")
+	assert.Equal(t, "/var/lib/linux/hoge-c508092e97c59149a8644827e066ca83.json", filepath.ToSlash(sPath), "arguments should be cared")
 }
 
-func TestWriteBytesToSkip(t *testing.T) {
-	f := ".tmp/fuga/piyo"
-	err := writeBytesToSkip(f, 15)
+func TestSaveState(t *testing.T) {
+	f := ".tmp/fuga/piyo.json"
+	err := saveState(f, &state{SkipBytes: 15})
 	assert.Equal(t, err, nil, "err should be nil")
 
-	skipBytes, err := getBytesToSkip(f)
+	state, err := loadState(f)
 	assert.Equal(t, err, nil, "err should be nil")
-	assert.Equal(t, skipBytes, int64(15))
+	assert.Equal(t, state.SkipBytes, int64(15))
+}
+
+func TestGetBytesToSkip(t *testing.T) {
+	// fallback testing for backward compability
+	oldf := ".tmp/fuga/piyo"
+	newf := ".tmp/fuga/piyo.json"
+	state := &state{SkipBytes: 15}
+	writeFileAtomically(oldf, []byte(fmt.Sprintf("%d", state.SkipBytes)))
+	defer os.RemoveAll(".tmp")
+
+	n, err := getBytesToSkip(newf)
+	assert.Equal(t, err, nil, "err should be nil")
+	assert.Equal(t, state.SkipBytes, n)
+
+	saveState(newf, state)
+
+	n, err = getBytesToSkip(newf)
+	assert.Equal(t, err, nil, "err should be nil")
+	assert.Equal(t, state.SkipBytes, n)
 }
 
 func TestSearchReader(t *testing.T) {


### PR DESCRIPTION
It is for future extensions such as https://github.com/mackerelio/go-check-plugins/pull/250. 
This PR supports backward compatibility for old style of status file.