### PR TITLE
add User-Agent header to http check plugins

### DIFF
--- a/check-elasticsearch/lib/check_elasticsearch.go
+++ b/check-elasticsearch/lib/check_elasticsearch.go
@@ -42,7 +42,7 @@ func run(args []string) *checkers.Checker {
 
 	req, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
-		return checkers.Critical(err.Error())
+		return checkers.Unknown(err.Error())
 	}
 	req.Header.Set("User-Agent", "check-elasticsearch")
 

--- a/check-elasticsearch/lib/check_elasticsearch.go
+++ b/check-elasticsearch/lib/check_elasticsearch.go
@@ -39,7 +39,14 @@ func run(args []string) *checkers.Checker {
 	url := fmt.Sprintf("%s://%s:%d/_cluster/health", opts.Scheme, opts.Host, opts.Port)
 
 	stTime := time.Now()
-	resp, err := client.Get(url)
+
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return checkers.Critical(err.Error())
+	}
+	req.Header.Set("User-Agent", "check-elasticsearch")
+
+	resp, err := client.Do(req)
 	if err != nil {
 		return checkers.Critical(err.Error())
 	}

--- a/check-http/lib/check_http.go
+++ b/check-http/lib/check_http.go
@@ -146,7 +146,7 @@ func Run(args []string) *checkers.Checker {
 		return nil
 	}
 
-	req, err := http.NewRequest("GET", opts.URL, nil)
+	req, err := http.NewRequest(http.MethodGet, opts.URL, nil)
 	if err != nil {
 		return checkers.Critical(err.Error())
 	}
@@ -164,6 +164,11 @@ func Run(args []string) *checkers.Checker {
 		}
 
 		req.Header = header
+	}
+
+	// set default User-Agent unless specified by `opts.Headers`
+	if _, ok := req.Header["User-Agent"]; !ok {
+		req.Header.Set("User-Agent", "check-http")
 	}
 
 	stTime := time.Now()

--- a/check-http/lib/check_http.go
+++ b/check-http/lib/check_http.go
@@ -148,7 +148,7 @@ func Run(args []string) *checkers.Checker {
 
 	req, err := http.NewRequest(http.MethodGet, opts.URL, nil)
 	if err != nil {
-		return checkers.Critical(err.Error())
+		return checkers.Unknown(err.Error())
 	}
 
 	if len(opts.Headers) != 0 {

--- a/check-jmx-jolokia/lib/check_jmx_jolokia.go
+++ b/check-jmx-jolokia/lib/check_jmx_jolokia.go
@@ -55,7 +55,13 @@ func run(args []string) *checkers.Checker {
 	}
 
 	client := &http.Client{Timeout: time.Duration(opts.Timeout) * time.Second}
-	res, err := client.Get(createURL(opts))
+	req, err := http.NewRequest(http.MethodGet, createURL(opts), nil)
+	if err != nil {
+		return checkers.Critical(err.Error())
+	}
+	req.Header.Set("User-Agent", "check-jmx-jolokia")
+
+	res, err := client.Do(req)
 	if err != nil {
 		return checkers.Critical(err.Error())
 	}

--- a/check-jmx-jolokia/lib/check_jmx_jolokia.go
+++ b/check-jmx-jolokia/lib/check_jmx_jolokia.go
@@ -57,7 +57,7 @@ func run(args []string) *checkers.Checker {
 	client := &http.Client{Timeout: time.Duration(opts.Timeout) * time.Second}
 	req, err := http.NewRequest(http.MethodGet, createURL(opts), nil)
 	if err != nil {
-		return checkers.Critical(err.Error())
+		return checkers.Unknown(err.Error())
 	}
 	req.Header.Set("User-Agent", "check-jmx-jolokia")
 

--- a/check-solr/lib/ping.go
+++ b/check-solr/lib/ping.go
@@ -10,7 +10,15 @@ import (
 
 func checkPing(opts solrOpts) *checkers.Checker {
 	uri := opts.createBaseURL() + "/admin/ping?wt=json"
-	resp, err := http.Get(uri)
+
+	req, err := http.NewRequest(http.MethodGet, uri, nil)
+	if err != nil {
+		return checkers.Critical(err.Error())
+	}
+	req.Header.Set("User-Agent", "check-solr")
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
 	if err != nil {
 		return checkers.Unknown("couldn't get access to " + uri)
 	}

--- a/check-solr/lib/ping.go
+++ b/check-solr/lib/ping.go
@@ -13,7 +13,7 @@ func checkPing(opts solrOpts) *checkers.Checker {
 
 	req, err := http.NewRequest(http.MethodGet, uri, nil)
 	if err != nil {
-		return checkers.Critical(err.Error())
+		return checkers.Unknown(err.Error())
 	}
 	req.Header.Set("User-Agent", "check-solr")
 

--- a/check-solr/lib/ping.go
+++ b/check-solr/lib/ping.go
@@ -17,8 +17,7 @@ func checkPing(opts solrOpts) *checkers.Checker {
 	}
 	req.Header.Set("User-Agent", "check-solr")
 
-	client := &http.Client{}
-	resp, err := client.Do(req)
+	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return checkers.Unknown("couldn't get access to " + uri)
 	}


### PR DESCRIPTION
Currently check plugins request to target HTTP endpoints with `net/http`'s default user-agent "Go-http-client/1.1".
In `check-http`, users can override it by the HTTP header option, but others cannot event override.

With this p-r:
- in `check-http`, fill default user-agent if `opts.Header` doesn't specify one
- in other check plugins which does HTTP request, set user-agent

All (default) user-agents are simply their plugin names like `check-http`.