### PR TITLE
[check-redis]: avoid to generate unknown alert if role is master

### DIFF
--- a/check-redis/lib/check-redis.go
+++ b/check-redis/lib/check-redis.go
@@ -151,6 +151,14 @@ func checkSlave(args []string) *checkers.Checker {
 	}
 	defer c.Close()
 
+	if role, ok := (*info)["role"]; ok {
+		if role == "master" {
+			return checkers.Ok("role is master")
+		}
+	} else {
+		return checkers.Unknown("couldn't get role")
+	}
+
 	if status, ok := (*info)["master_link_status"]; ok {
 		msg := fmt.Sprintf("master_link_status: %s", status)
 
@@ -164,7 +172,6 @@ func checkSlave(args []string) *checkers.Checker {
 		}
 
 	} else {
-		// it may be a master!
 		return checkers.Unknown("couldn't get master_link_status")
 	}
 }


### PR DESCRIPTION
# Problem

Currently check-redis generates unknown alert if role is master, so 
in the cluster of role:master's host role:slave's host, I set a `check-redis slave` check monitor configuration into an only role:slave:s host.  
Redis role can dynamically change, so it is troublesome to change the check monitor configuration manually.

# Before

```
[y_uuki@redis ~]$ redis-cli info | grep role
role:master
[y_uuki@redis ~]$ check-redis slave
Redis Slave UNKNOWN: couldn't get master_link_status
```

# After

```
[y_uuki@redis ~]$ redis-cli info | grep role
role:master
[y_uuki@redis ~]$ ./check-redis  slave
Redis Slave OK: role is master
```