### PR TITLE
[check-redis] add replication subcommand

### DIFF
--- a/check-redis/lib/check-redis.go
+++ b/check-redis/lib/check-redis.go
@@ -23,7 +23,7 @@ type redisSetting struct {
 var commands = map[string](func([]string) *checkers.Checker){
 	"reachable":   checkReachable,
 	"replication": checkReplication,
-	"slave":       checkSlave,
+	"slave":       checkSlave, // deprecated command
 }
 
 func separateSub(argv []string) (string, []string) {
@@ -177,10 +177,13 @@ func checkReplication(args []string) *checkers.Checker {
 	}
 }
 
+// Deprecated: For backward compatibility.
 func checkSlave(args []string) *checkers.Checker {
 	opts := redisSetting{}
 	psr := flags.NewParser(&opts, flags.Default)
-	psr.Usage = "slave [OPTIONS]"
+	psr.Usage = `slave [OPTIONS]
+
+DEPRECATED: For backward compatibility. Use 'replication' command.`
 	_, err := psr.ParseArgs(args)
 	if err != nil {
 		fmt.Println(err)


### PR DESCRIPTION
add replication subcommand insteam of slave
because it seems that the behavior that slave command returns OK if role is master is not intuitive in the PR(https://github.com/mackerelio/go-check-plugins/pull/259).

```
[y_uuki@redis01 ~]$ redis-cli info | grep role
role:master
[y_uuki@redis01 ~]$ ./check-redis replication
Redis Replication UNKNOWN: couldn't get master_link_status
[y_uuki@redis01 ~]$ ./check-redis replication --skip-master
Redis Replication OK: role is master
```

```
[y_uuki@redis002 ~]$ redis-cli info | grep role
role:slave
[y_uuki@redis002 ~]$ ./check-redis replication
Redis Replication OK: master_link_status: up
```
