### PR TITLE
[check-http] Support --connect-to option

### DIFF
--- a/check-http/README.md
+++ b/check-http/README.md
@@ -15,4 +15,9 @@ check-http -s 404=ok -u http://example.com
 check-http -s 200-404=ok -u http://example.com
 ```
 
-
+To change request destination
+```shell
+check-http --connect-to=example.com:443:127.0.0.1:8080 https://example.com # will request to 127.0.0.1:8000 but AS example.com:443
+check-http --connect-to=:443:127.0.0.1:8080 https://example.com # empty host matches ANY host
+check-http --connect-to=example.com::127.0.0.1:8080 https://example.com # empty port matches ANY port
+```

--- a/check-http/README.md
+++ b/check-http/README.md
@@ -18,6 +18,8 @@ check-http -s 200-404=ok -u http://example.com
 To change request destination
 ```shell
 check-http --connect-to=example.com:443:127.0.0.1:8080 https://example.com # will request to 127.0.0.1:8000 but AS example.com:443
-check-http --connect-to=:443:127.0.0.1:8080 https://example.com # empty host matches ANY host
-check-http --connect-to=example.com::127.0.0.1:8080 https://example.com # empty port matches ANY port
+check-http --connect-to=:443:127.0.0.1:8080 https://example.com # empty host1 matches ANY host
+check-http --connect-to=example.com::127.0.0.1:8080 https://example.com # empty port1 matches ANY port
+check-http --connect-to=localhost:443::8080 https://localhost # empty host2 means unchanged, therefore will request to localhost:8080 AS localhost:443
+check-http --connect-to=example.com:443:127.0.0.1: https://example.com # empty port2 means unchanged, therefore will request to 127.0.0.1:443
 ```

--- a/check-http/lib/check_http.go
+++ b/check-http/lib/check_http.go
@@ -153,6 +153,9 @@ func parseConnectTo(opts *checkHTTPOpts) ([]resolveMapping, error) {
 	mappings := make([]resolveMapping, len(opts.ConnectTos))
 	for i, c := range opts.ConnectTos {
 		s := connectToRegexp.FindStringSubmatch(c)
+		if len(s) == 0 {
+			return nil, fmt.Errorf("Invalid --connect-to pattern: %s", c)
+		}
 		r := resolveMapping{}
 		if len(s) >= 2 {
 			r.srcHost = s[1]

--- a/check-http/lib/check_http.go
+++ b/check-http/lib/check_http.go
@@ -71,6 +71,7 @@ func newReplacableDial(dialer *net.Dialer, mappings []resolveMapping) func(ctx c
 				continue
 			}
 			addr = net.JoinHostPort(m.destHost, m.destPort)
+			break
 		}
 		return dialer.DialContext(ctx, network, addr)
 	}

--- a/check-http/lib/check_http_test.go
+++ b/check-http/lib/check_http_test.go
@@ -209,15 +209,27 @@ func TestConnectTos(t *testing.T) {
 			want: checkers.OK,
 		},
 		{
-			// empty host means ANY
+			// empty srcHost means ANY
 			args: []string{"--connect-to", fmt.Sprintf(":80:%s:%s", addr, port),
 				"-u", "http://hoge"},
 			want: checkers.OK,
 		},
 		{
-			// empty port means ANY
+			// empty srcPort means ANY
 			args: []string{"--connect-to", fmt.Sprintf("hoge::%s:%s", addr, port),
 				"-u", "http://hoge"},
+			want: checkers.OK,
+		},
+		{
+			// empty destHost means unchanged
+			args: []string{"--connect-to", fmt.Sprintf("%s:80::%s", addr, port),
+				"-u", fmt.Sprintf("http://%s", addr)},
+			want: checkers.OK,
+		},
+		{
+			// empty destPort means unchanged
+			args: []string{"--connect-to", fmt.Sprintf("hoge:%s:%s:", port, addr),
+				"-u", fmt.Sprintf("http://hoge:%s", port)},
 			want: checkers.OK,
 		},
 		{

--- a/check-http/lib/check_http_test.go
+++ b/check-http/lib/check_http_test.go
@@ -270,6 +270,12 @@ func TestConnectTos(t *testing.T) {
 				"-u", "http://hoge"},
 			want: checkers.OK,
 		},
+		{
+			// Invalid pattern
+			args: []string{"--connect-to", "foo:123:",
+				"-u", ts.URL},
+			want: checkers.UNKNOWN,
+		},
 	}
 
 	for i, tc := range testCases {


### PR DESCRIPTION
Same as `curl`'s --connect-to option, which is added in 7.49.0.

```shell
# will request to 127.0.0.1:8000 but AS example.com:443
check-http --connect-to=example.com:443:127.0.0.1:8080 https://example.com

# empty host matches ANY host
check-http --connect-to=:443:127.0.0.1:8080 https://example.com

# empty port matches ANY port
check-http --connect-to=example.com::127.0.0.1:8080 https://example.com

# only changes host (=> 127.0.0.1:443)
check-http --connect-to=example.com::127.0.0.1: https://example.com

# only changes port (=> 127.0.0.1:8080)
check-http --connect-to=:443::8080 https://127.0.0.1
```

# Motivation

"My app host serves https://mackerel.io/, and I'd like to check it's https response".

- In HTTP, `check-http -H Host: mackerel.io http://127.0.0.1/` works
- If I'm not interested in certs, `check-http --no-check-certificate -H Host: mackerel.io https://127.0.0.1` works
- but I'm interested not only HTTP response but also HTTPS certificate!

# Implementation

I cared ipv6's address roughly, but not tested its real behavior. (necessary?)