### PR TITLE
[check-disk] skip checks if there are no inodes

### DIFF
--- a/check-disk/lib/check-disk.go
+++ b/check-disk/lib/check-disk.go
@@ -48,6 +48,7 @@ func checkStatus(current checkers.Status, threshold string, units float64, disk 
 		freePct := float64(100) - disk.UsedPercent
 		inodesFreePct := float64(100) - disk.InodesUsedPercent
 
+		// Skip checking if disk.InodesTotal == 0 since inodesFreePct is meaningless.
 		if chkInode && (disk.InodesTotal != 0 && thresholdPct > inodesFreePct) {
 			current = status
 		}

--- a/check-disk/lib/check-disk.go
+++ b/check-disk/lib/check-disk.go
@@ -276,12 +276,12 @@ func filterPartitionsByInclusion(partitions []gpud.PartitionStat, list []string,
 	for _, partition := range partitions {
 		var ok = false
 		for _, l := range list {
-			if (l == key(partition)) {
+			if l == key(partition) {
 				ok = true
 				break
 			}
 		}
-		if (ok) {
+		if ok {
 			newPartitions = append(newPartitions, partition)
 		}
 	}
@@ -294,12 +294,12 @@ func filterPartitionsByExclusion(partitions []gpud.PartitionStat, list []string,
 	for _, partition := range partitions {
 		var ok = true
 		for _, l := range list {
-			if (l == key(partition)) {
+			if l == key(partition) {
 				ok = false
 				break
 			}
 		}
-		if (ok) {
+		if ok {
 			newPartitions = append(newPartitions, partition)
 		}
 	}

--- a/check-disk/lib/check-disk.go
+++ b/check-disk/lib/check-disk.go
@@ -46,17 +46,13 @@ func checkStatus(current checkers.Status, threshold string, units float64, disk 
 		}
 
 		freePct := float64(100) - disk.UsedPercent
-
 		inodesFreePct := float64(100) - disk.InodesUsedPercent
-		if float64(disk.InodesTotal) == float64(0) {
-			inodesFreePct = float64(0)
-		}
 
-		if chkInode && v > inodesFreePct {
+		if chkInode && (disk.InodesTotal != 0 && v > inodesFreePct) {
 			current = status
 		}
 
-		if !chkInode && (v > freePct || v > inodesFreePct) {
+		if !chkInode && (v > freePct || (disk.InodesTotal != 0 && v > inodesFreePct)) {
 			current = status
 		}
 	} else {

--- a/check-disk/lib/check-disk.go
+++ b/check-disk/lib/check-disk.go
@@ -40,7 +40,7 @@ type unit struct {
 
 func checkStatus(current checkers.Status, threshold string, units float64, disk *gpud.UsageStat, chkInode bool, status checkers.Status) (checkers.Status, error) {
 	if strings.HasSuffix(threshold, "%") {
-		v, err := strconv.ParseFloat(strings.TrimRight(threshold, "%"), 64)
+		thresholdPct, err := strconv.ParseFloat(strings.TrimRight(threshold, "%"), 64)
 		if err != nil {
 			return checkers.UNKNOWN, err
 		}
@@ -48,11 +48,11 @@ func checkStatus(current checkers.Status, threshold string, units float64, disk 
 		freePct := float64(100) - disk.UsedPercent
 		inodesFreePct := float64(100) - disk.InodesUsedPercent
 
-		if chkInode && (disk.InodesTotal != 0 && v > inodesFreePct) {
+		if chkInode && (disk.InodesTotal != 0 && thresholdPct > inodesFreePct) {
 			current = status
 		}
 
-		if !chkInode && (v > freePct || (disk.InodesTotal != 0 && v > inodesFreePct)) {
+		if !chkInode && (thresholdPct > freePct || (disk.InodesTotal != 0 && thresholdPct > inodesFreePct)) {
 			current = status
 		}
 	} else {
@@ -60,13 +60,13 @@ func checkStatus(current checkers.Status, threshold string, units float64, disk 
 			return checkers.UNKNOWN, errors.New("-W, -K value should be N%")
 		}
 
-		v, err := strconv.ParseFloat(threshold, 64)
+		thresholdVal, err := strconv.ParseFloat(threshold, 64)
 		if err != nil {
 			return checkers.UNKNOWN, err
 		}
 
 		free := float64(disk.Free) / units
-		if v > free {
+		if thresholdVal > free {
 			current = status
 		}
 	}


### PR DESCRIPTION
On Windows, there are no "inodes" and checks on them should be skipped.
However, the current version always raises wranings / errors if `-w N%` / `-c N%` is specified.
This PR fixes it by skipping checks if total inodes is zero (`gopsutil/disk` returns `InodesTotal = 0` on Windows https://github.com/shirou/gopsutil/blob/master/disk/disk_windows.go).

The change may affect other (non-Windows) environments, but I think it is OK because talking about the "percentage" of 0/0 is nonsense...
