### PR TITLE
[check-disk] Do not check inodes% along with disk%

### DIFF
--- a/check-disk/lib/check-disk.go
+++ b/check-disk/lib/check-disk.go
@@ -53,7 +53,7 @@ func checkStatus(current checkers.Status, threshold string, units float64, disk 
 			current = status
 		}
 
-		if !chkInode && (thresholdPct > freePct || (disk.InodesTotal != 0 && thresholdPct > inodesFreePct)) {
+		if !chkInode && (thresholdPct > freePct) {
 			current = status
 		}
 	} else {

--- a/check-disk/lib/check-disk.go
+++ b/check-disk/lib/check-disk.go
@@ -91,9 +91,14 @@ func genMessage(disk *gpud.UsageStat, u unit) string {
 	used := float64(disk.Used) / u.Size
 	free := float64(disk.Free) / u.Size
 	freePct := float64(100) - disk.UsedPercent
-	inodesFreePct := float64(100) - disk.InodesUsedPercent
 
-	return fmt.Sprintf("Path: %v, All: %.2f %v, Used: %.2f %v, Free: %.2f %v, Free percentage: %.2f (inodes: %.2f)", disk.Path, all, u.Name, used, u.Name, free, u.Name, freePct, inodesFreePct)
+	inodesFreePctStr := ""
+	if disk.InodesTotal != 0 {
+		inodesFreePct := float64(100) - disk.InodesUsedPercent
+		inodesFreePctStr = fmt.Sprintf(" (inodes %.2f)", inodesFreePct)
+	}
+
+	return fmt.Sprintf("Path: %v, All: %.2f %v, Used: %.2f %v, Free: %.2f %v, Free percentage: %.2f%s", disk.Path, all, u.Name, used, u.Name, free, u.Name, freePct, inodesFreePctStr)
 }
 
 // Do the plugin

--- a/check-disk/lib/check-disk.go
+++ b/check-disk/lib/check-disk.go
@@ -74,9 +74,8 @@ func checkInodes(current checkers.Status, threshold string, disk *gpud.UsageStat
 		return checkers.UNKNOWN, err
 	}
 
-	// Skip checking if disk.InodesTotal == 0 since inodesFreePct is meaningless.
 	if disk.InodesTotal == 0 {
-		return current, nil
+		return checkers.UNKNOWN, fmt.Errorf("Disk %s does not have inodes", disk.Path)
 	}
 
 	inodesFreePct := float64(100) - disk.InodesUsedPercent

--- a/check-disk/lib/check-disk.go
+++ b/check-disk/lib/check-disk.go
@@ -65,26 +65,26 @@ func checkDisk(current checkers.Status, threshold string, units float64, disk *g
 }
 
 func checkInodes(current checkers.Status, threshold string, disk *gpud.UsageStat, status checkers.Status) (checkers.Status, error) {
-	if strings.HasSuffix(threshold, "%") {
-		thresholdPct, err := strconv.ParseFloat(strings.TrimRight(threshold, "%"), 64)
-		if err != nil {
-			return checkers.UNKNOWN, err
-		}
-
-		// Skip checking if disk.InodesTotal == 0 since inodesFreePct is meaningless.
-		if disk.InodesTotal == 0 {
-			return current, nil
-		}
-
-		inodesFreePct := float64(100) - disk.InodesUsedPercent
-		if thresholdPct > inodesFreePct {
-			current = status
-		}
-
-		return current, nil
-	} else {
+	if !strings.HasSuffix(threshold, "%") {
 		return checkers.UNKNOWN, errors.New("-W, -K value should be N%")
 	}
+
+	thresholdPct, err := strconv.ParseFloat(strings.TrimRight(threshold, "%"), 64)
+	if err != nil {
+		return checkers.UNKNOWN, err
+	}
+
+	// Skip checking if disk.InodesTotal == 0 since inodesFreePct is meaningless.
+	if disk.InodesTotal == 0 {
+		return current, nil
+	}
+
+	inodesFreePct := float64(100) - disk.InodesUsedPercent
+	if thresholdPct > inodesFreePct {
+		current = status
+	}
+
+	return current, nil
 }
 
 func genMessage(disk *gpud.UsageStat, u unit) string {

--- a/check-disk/lib/check-disk.go
+++ b/check-disk/lib/check-disk.go
@@ -38,7 +38,7 @@ type unit struct {
 	Size float64
 }
 
-func checkStatus(current checkers.Status, threshold string, units float64, disk *gpud.UsageStat, chkInode bool, status checkers.Status) (checkers.Status, error) {
+func checkDisk(current checkers.Status, threshold string, units float64, disk *gpud.UsageStat, status checkers.Status) (checkers.Status, error) {
 	if strings.HasSuffix(threshold, "%") {
 		thresholdPct, err := strconv.ParseFloat(strings.TrimRight(threshold, "%"), 64)
 		if err != nil {
@@ -46,21 +46,10 @@ func checkStatus(current checkers.Status, threshold string, units float64, disk 
 		}
 
 		freePct := float64(100) - disk.UsedPercent
-		inodesFreePct := float64(100) - disk.InodesUsedPercent
-
-		// Skip checking if disk.InodesTotal == 0 since inodesFreePct is meaningless.
-		if chkInode && (disk.InodesTotal != 0 && thresholdPct > inodesFreePct) {
-			current = status
-		}
-
-		if !chkInode && (thresholdPct > freePct) {
+		if thresholdPct > freePct {
 			current = status
 		}
 	} else {
-		if chkInode {
-			return checkers.UNKNOWN, errors.New("-W, -K value should be N%")
-		}
-
 		thresholdVal, err := strconv.ParseFloat(threshold, 64)
 		if err != nil {
 			return checkers.UNKNOWN, err
@@ -73,6 +62,29 @@ func checkStatus(current checkers.Status, threshold string, units float64, disk 
 	}
 
 	return current, nil
+}
+
+func checkInodes(current checkers.Status, threshold string, disk *gpud.UsageStat, status checkers.Status) (checkers.Status, error) {
+	if strings.HasSuffix(threshold, "%") {
+		thresholdPct, err := strconv.ParseFloat(strings.TrimRight(threshold, "%"), 64)
+		if err != nil {
+			return checkers.UNKNOWN, err
+		}
+
+		// Skip checking if disk.InodesTotal == 0 since inodesFreePct is meaningless.
+		if disk.InodesTotal == 0 {
+			return current, nil
+		}
+
+		inodesFreePct := float64(100) - disk.InodesUsedPercent
+		if thresholdPct > inodesFreePct {
+			current = status
+		}
+
+		return current, nil
+	} else {
+		return checkers.UNKNOWN, errors.New("-W, -K value should be N%")
+	}
 }
 
 func genMessage(disk *gpud.UsageStat, u unit) string {
@@ -169,7 +181,7 @@ func run(args []string) *checkers.Checker {
 	checkSt := checkers.OK
 	if opts.InodeCritical != nil {
 		for _, disk := range disks {
-			checkSt, err = checkStatus(checkSt, *opts.InodeCritical, u.Size, disk, true, checkers.CRITICAL)
+			checkSt, err = checkInodes(checkSt, *opts.InodeCritical, disk, checkers.CRITICAL)
 			if err != nil {
 				return checkers.Unknown(fmt.Sprintf("Failed to check disk status: %s", err))
 			}
@@ -182,7 +194,7 @@ func run(args []string) *checkers.Checker {
 
 	if checkSt != checkers.CRITICAL && opts.Critical != nil {
 		for _, disk := range disks {
-			checkSt, err = checkStatus(checkSt, *opts.Critical, u.Size, disk, false, checkers.CRITICAL)
+			checkSt, err = checkDisk(checkSt, *opts.Critical, u.Size, disk, checkers.CRITICAL)
 			if err != nil {
 				return checkers.Unknown(fmt.Sprintf("Failed to check disk status: %s", err))
 			}
@@ -195,7 +207,7 @@ func run(args []string) *checkers.Checker {
 
 	if checkSt != checkers.CRITICAL && opts.InodeWarning != nil {
 		for _, disk := range disks {
-			checkSt, err = checkStatus(checkSt, *opts.InodeWarning, u.Size, disk, true, checkers.WARNING)
+			checkSt, err = checkInodes(checkSt, *opts.InodeWarning, disk, checkers.WARNING)
 			if err != nil {
 				return checkers.Unknown(fmt.Sprintf("Failed to check disk status: %s", err))
 			}
@@ -208,7 +220,7 @@ func run(args []string) *checkers.Checker {
 
 	if checkSt == checkers.OK && opts.Warning != nil {
 		for _, disk := range disks {
-			checkSt, err = checkStatus(checkSt, *opts.Warning, u.Size, disk, false, checkers.WARNING)
+			checkSt, err = checkDisk(checkSt, *opts.Warning, u.Size, disk, checkers.WARNING)
 			if err != nil {
 				return checkers.Unknown(fmt.Sprintf("Failed to check disk status: %s", err))
 			}


### PR DESCRIPTION
As mentioned [here](https://github.com/mackerelio/go-check-plugins/pull/265#discussion_r241683338), checking inodes% when `-w N%` / `-c N%` specified is not preferable behavior, as the help does not refer to it.
This PR fixes it so that one can use `-w` / `-c` for disk% and `-W` / `-K` for inodes% separately.