### PR TITLE
Add check-json

### DIFF
--- a/check-json/README.md
+++ b/check-json/README.md
@@ -1,0 +1,25 @@
+check-json
+==========
+
+Check json.
+
+## Synopsis
+
+```shell
+check-http -u http://example.com
+```
+
+To override status
+```shell
+check-json -s 404=ok -u http://example.com
+check-json -s 200-404=ok -u http://example.com
+```
+
+To change request destination
+```shell
+check-json --connect-to=example.com:443:127.0.0.1:8080 https://example.com # will request to 127.0.0.1:8000 but AS example.com:443
+check-json --connect-to=:443:127.0.0.1:8080 https://example.com # empty host1 matches ANY host
+check-json --connect-to=example.com::127.0.0.1:8080 https://example.com # empty port1 matches ANY port
+check-json --connect-to=localhost:443::8080 https://localhost # empty host2 means unchanged, therefore will request to localhost:8080 AS localhost:443
+check-json --connect-to=example.com:443:127.0.0.1: https://example.com # empty port2 means unchanged, therefore will request to 127.0.0.1:443
+```

--- a/check-json/lib/check_json.go
+++ b/check-json/lib/check_json.go
@@ -1,0 +1,336 @@
+package checkjson
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"net/textproto"
+	"os"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/bhmj/jsonslice"
+	"github.com/jessevdk/go-flags"
+	"github.com/mackerelio/checkers"
+)
+
+// XXX more options
+type checkHTTPOpts struct {
+	URL                string   `short:"u" long:"url" required:"true" description:"A URL to connect to"`
+	Statuses           []string `short:"s" long:"status" description:"mapping of HTTP status"`
+	NoCheckCertificate bool     `long:"no-check-certificate" description:"Do not check certificate"`
+	SourceIP           string   `short:"i" long:"source-ip" description:"source IP address"`
+	Headers            []string `short:"H" description:"HTTP request headers"`
+	Regexp             string   `short:"p" long:"pattern" value-name:"EXPRESSION" description:"Expected regular expression pattern to compare value for selected key"`
+	MaxRedirects       int      `long:"max-redirects" description:"Maximum number of redirects followed" default:"10"`
+	ConnectTos         []string `long:"connect-to" value-name:"HOST1:PORT1:HOST2:PORT2" description:"Request to HOST2:PORT2 instead of HOST1:PORT1"`
+	Expression         string   `short:"k" long:"key" value-name:"EXPRESSION" default:"$" description:"Limit value checks to JSON object key matching expression using https://github.com/bhmj/jsonslice#expressions"`
+}
+
+// Do the plugin
+func Do() {
+	ckr := Run(os.Args[1:])
+	ckr.Name = "JSON"
+	ckr.Exit()
+}
+
+type statusRange struct {
+	min     int
+	max     int
+	checkSt checkers.Status
+}
+
+const invalidMapping = "Invalid mapping of status: %s"
+
+// when empty:
+// - src* will be treated as ANY
+// - dest* will be treated as unchanged
+type resolveMapping struct {
+	srcHost  string
+	srcPort  string
+	destHost string
+	destPort string
+}
+
+func newReplacableDial(dialer *net.Dialer, mappings []resolveMapping) func(ctx context.Context, network, addr string) (net.Conn, error) {
+	return func(ctx context.Context, network, hostport string) (net.Conn, error) {
+		host, port, err := net.SplitHostPort(hostport)
+		if err != nil {
+			return nil, err
+		}
+
+		addr := hostport
+		for _, m := range mappings {
+			if m.srcHost != "" && m.srcHost != host {
+				continue
+			}
+			if m.srcPort != "" && m.srcPort != port {
+				continue
+			}
+			if m.destHost != "" {
+				host = m.destHost
+			}
+			if m.destPort != "" {
+				port = m.destPort
+			}
+			addr = net.JoinHostPort(host, port)
+			break
+		}
+		return dialer.DialContext(ctx, network, addr)
+	}
+}
+
+func parseStatusRanges(opts *checkHTTPOpts) ([]statusRange, error) {
+	var statuses []statusRange
+	for _, s := range opts.Statuses {
+		token := strings.SplitN(s, "=", 2)
+		if len(token) != 2 {
+			return nil, fmt.Errorf(invalidMapping, s)
+		}
+		values := strings.Split(token[0], "-")
+
+		var r statusRange
+		var err error
+
+		switch len(values) {
+		case 1:
+			r.min, err = strconv.Atoi(values[0])
+			if err != nil {
+				return nil, fmt.Errorf(invalidMapping, s)
+			}
+			r.max = r.min
+		case 2:
+			r.min, err = strconv.Atoi(values[0])
+			if err != nil {
+				return nil, fmt.Errorf(invalidMapping, s)
+			}
+			r.max, err = strconv.Atoi(values[1])
+			if err != nil {
+				return nil, fmt.Errorf(invalidMapping, s)
+			}
+			if r.min > r.max {
+				return nil, fmt.Errorf(invalidMapping, s)
+			}
+		default:
+			return nil, fmt.Errorf(invalidMapping, s)
+		}
+
+		switch strings.ToUpper(token[1]) {
+		case "OK":
+			r.checkSt = checkers.OK
+		case "WARNING":
+			r.checkSt = checkers.WARNING
+		case "CRITICAL":
+			r.checkSt = checkers.CRITICAL
+		case "UNKNOWN":
+			r.checkSt = checkers.UNKNOWN
+		default:
+			return nil, fmt.Errorf(invalidMapping, s)
+		}
+		statuses = append(statuses, r)
+	}
+	return statuses, nil
+}
+
+func parseHeader(opts *checkHTTPOpts) (http.Header, error) {
+	reader := bufio.NewReader(strings.NewReader(strings.Join(opts.Headers, "\r\n") + "\r\n\r\n"))
+	tp := textproto.NewReader(reader)
+	mimeheader, err := tp.ReadMIMEHeader()
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse header: %s", err)
+	}
+	return http.Header(mimeheader), nil
+}
+
+var connectToRegexp = regexp.MustCompile(`^(\[.+\]|[^\[\]]+)?:(\d*):(\[.+\]|[^\[\]]+)?:(\d+)?$`)
+
+func parseConnectTo(opts *checkHTTPOpts) ([]resolveMapping, error) {
+	mappings := make([]resolveMapping, len(opts.ConnectTos))
+	for i, c := range opts.ConnectTos {
+		s := connectToRegexp.FindStringSubmatch(c)
+		if len(s) == 0 {
+			return nil, fmt.Errorf("Invalid --connect-to pattern: %s", c)
+		}
+		r := resolveMapping{}
+		if len(s) >= 2 {
+			r.srcHost = s[1]
+		}
+		if len(s) >= 3 {
+			r.srcPort = s[2]
+		}
+		if len(s) >= 4 {
+			r.destHost = s[3]
+		}
+		if len(s) >= 5 {
+			r.destPort = s[4]
+		}
+		mappings[i] = r
+	}
+	return mappings, nil
+}
+
+// Run do external monitoring via HTTP
+func Run(args []string) *checkers.Checker {
+	opts := checkHTTPOpts{}
+	_, err := flags.ParseArgs(&opts, args)
+	if err != nil {
+		os.Exit(1)
+	}
+
+	statusRanges, err := parseStatusRanges(&opts)
+	if err != nil {
+		return checkers.Unknown(err.Error())
+	}
+
+	tr := &http.Transport{
+		TLSClientConfig: &tls.Config{
+			InsecureSkipVerify: opts.NoCheckCertificate,
+		},
+		Proxy: http.ProxyFromEnvironment,
+	}
+	// same as http.Transport's default dialer
+	dialer := &net.Dialer{
+		Timeout:   30 * time.Second,
+		KeepAlive: 30 * time.Second,
+		DualStack: true,
+	}
+	if opts.SourceIP != "" {
+		ip := net.ParseIP(opts.SourceIP)
+		if ip == nil {
+			return checkers.Unknown(fmt.Sprintf("Invalid source IP address: %v", opts.SourceIP))
+		}
+		dialer.LocalAddr = &net.TCPAddr{IP: ip}
+	}
+
+	if len(opts.ConnectTos) != 0 {
+		resolves, err := parseConnectTo(&opts)
+		if err != nil {
+			return checkers.Unknown(err.Error())
+		}
+		tr.DialContext = newReplacableDial(dialer, resolves)
+	}
+	client := &http.Client{Transport: tr}
+	client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+		if len(via) > opts.MaxRedirects {
+			return http.ErrUseLastResponse
+		}
+		return nil
+	}
+
+	req, err := http.NewRequest(http.MethodGet, opts.URL, nil)
+	if err != nil {
+		return checkers.Unknown(err.Error())
+	}
+
+	if len(opts.Headers) != 0 {
+		header, err := parseHeader(&opts)
+		if err != nil {
+			return checkers.Unknown(err.Error())
+		}
+
+		// Host header must be set via req.Host
+		if host := header.Get("Host"); len(host) != 0 {
+			req.Host = host
+			header.Del("Host")
+		}
+
+		req.Header = header
+	}
+
+	// set default User-Agent unless specified by `opts.Headers`
+	if _, ok := req.Header["User-Agent"]; !ok {
+		req.Header.Set("User-Agent", "check-http")
+	}
+
+	stTime := time.Now()
+	resp, err := client.Do(req)
+	if err != nil {
+		return checkers.Critical(err.Error())
+	}
+	elapsed := time.Since(stTime)
+	defer resp.Body.Close()
+
+	body, _ := ioutil.ReadAll(resp.Body)
+
+	cLength := resp.ContentLength
+	if cLength == -1 {
+		cLength = int64(len(body))
+	}
+
+	checkSt := checkers.UNKNOWN
+
+	found := false
+	for _, st := range statusRanges {
+		if st.min <= resp.StatusCode && resp.StatusCode <= st.max {
+			checkSt = st.checkSt
+			found = true
+			break
+		}
+	}
+
+	if !found {
+		switch st := resp.StatusCode; true {
+		case st < 400:
+			checkSt = checkers.OK
+		case st < 500:
+			checkSt = checkers.WARNING
+		default:
+			checkSt = checkers.CRITICAL
+		}
+	}
+
+	respMsg := new(bytes.Buffer)
+
+	checkSt = checkers.OK
+
+	if opts.Expression == "" {
+		opts.Expression = "$"
+	}
+
+	v, err := jsonslice.Get(body, opts.Expression)
+	if err != nil {
+		fmt.Fprintf(respMsg, "%s\n", err)
+		return checkers.NewChecker(checkers.CRITICAL, respMsg.String())
+	}
+
+	if isJSON(string(body)) != true {
+		fmt.Fprintf(respMsg, "JSON ERROR: not a valid JSON document\n")
+		return checkers.NewChecker(checkers.CRITICAL, respMsg.String())
+	}
+
+	if opts.Regexp != "" {
+		re, err := regexp.Compile(opts.Regexp)
+		if err != nil {
+			return checkers.Unknown(err.Error())
+		}
+		if !re.Match(v) {
+			fmt.Fprintf(respMsg, "expected '%s', got '%s' at '%s'\n", opts.Regexp, v, opts.Expression)
+			return checkers.NewChecker(checkers.CRITICAL, respMsg.String())
+		}
+
+		fmt.Fprintf(respMsg, "'%s' matches pattern '%s'\n", v, opts.Regexp)
+		//		return checkers.NewChecker(checkers.OK, respMsg.String())
+
+	} else {
+		fmt.Fprintf(respMsg, "found '%s' at '%s'\n", v, opts.Expression)
+	}
+
+	fmt.Fprintf(respMsg, "%s %s - %d bytes in %f second response time",
+		resp.Proto, resp.Status, cLength, elapsed.Seconds())
+
+	return checkers.NewChecker(checkSt, respMsg.String())
+}
+
+func isJSON(s string) bool {
+	var js map[string]interface{}
+	return json.Unmarshal([]byte(s), &js) == nil
+
+}

--- a/check-json/lib/check_json_test.go
+++ b/check-json/lib/check_json_test.go
@@ -1,0 +1,285 @@
+package checkjson
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/mackerelio/checkers"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRun(t *testing.T) {
+	ckr := Run([]string{"-u", "hoge"})
+	assert.Equal(t, ckr.Status, checkers.CRITICAL, "chr.Status should be CRITICAL")
+	assert.Equal(t, ckr.Message, `Get hoge: unsupported protocol scheme ""`, "something went wrong")
+}
+
+func TestNoCheckCertificate(t *testing.T) {
+	ckr := Run([]string{"--no-check-certificate", "-u", "hoge"})
+	assert.Equal(t, ckr.Status, checkers.CRITICAL, "chr.Status should be CRITICAL")
+	assert.Equal(t, ckr.Message, `Get hoge: unsupported protocol scheme ""`, "something went wrong")
+}
+
+func TestStatusRange(t *testing.T) {
+	tests := []struct {
+		args []string
+		want checkers.Status
+		err  bool
+	}{
+		{
+			args: []string{"-s", "404=ok", "-u", "hoge"},
+			want: checkers.CRITICAL,
+		},
+		{
+			args: []string{"-s", "404=ok", "-u", "https://mackerel.io/404"},
+			want: checkers.OK,
+		},
+		{
+			args: []string{"-s", "401=ok", "-u", "https://mackerel.io/404"},
+			want: checkers.WARNING,
+		},
+		{
+			args: []string{"-s", "300-404=ok", "-u", "https://mackerel.io/404"},
+			want: checkers.OK,
+		},
+		{
+			args: []string{"-s", "200-300-404=ok", "-u", "http://example.com"},
+			want: checkers.UNKNOWN,
+		},
+		{
+			args: []string{"-s", "300=ok", "-s", "404=ok", "-u", "https://mackerel.io/404"},
+			want: checkers.OK,
+		},
+		{
+			args: []string{"-s", "300", "-s", "404=ok", "-u", "https://mackerel.io/404"},
+			want: checkers.UNKNOWN,
+		},
+		{
+			args: []string{"-s", "=ok", "-s", "404=ok", "-u", "https://mackerel.io/404"},
+			want: checkers.UNKNOWN,
+		},
+		{
+			args: []string{"-s", "=ok", "-s", "404-200=ok", "-u", "https://mackerel.io/404"},
+			want: checkers.UNKNOWN,
+		},
+	}
+	for _, tt := range tests {
+		ckr := Run(tt.args)
+		assert.Equal(t, ckr.Status, tt.want, fmt.Sprintf("chr.Status wrong: %v", ckr.Status))
+	}
+}
+
+func TestSourceIP(t *testing.T) {
+	ckr := Run([]string{"-u", "hoge", "-i", "1.2.3"})
+	assert.Equal(t, ckr.Status, checkers.UNKNOWN, "chr.Status should be UNKNOWN")
+}
+
+func TestHost(t *testing.T) {
+	testHost := "mackerel.io"
+	testHeader := "test"
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, testHost, r.Host)
+		header := r.Header
+		assert.Equal(t, testHeader, header.Get("TestHeader"))
+	}))
+	defer ts.Close()
+
+	ckr := Run([]string{
+		"-H", fmt.Sprintf("Host: %s", testHost),
+		"-H", fmt.Sprintf("TestHeader: %s", testHeader),
+		"-u", ts.URL,
+	})
+
+	assert.Equal(t, ckr.Status, checkers.OK, "ckr.Status should be OK")
+}
+
+func TestExpectedContent(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, "Hello, client")
+	}))
+	defer ts.Close()
+
+	testCases := []struct {
+		regexp string
+		status checkers.Status
+	}{
+		{
+			regexp: "Hello, client",
+			status: checkers.OK,
+		},
+		{
+			regexp: "Wrong response",
+			status: checkers.CRITICAL,
+		},
+		{
+			regexp: "Hel.*",
+			status: checkers.OK,
+		},
+		{
+			regexp: "clientt?",
+			status: checkers.OK,
+		},
+		{
+			regexp: "???",
+			status: checkers.UNKNOWN,
+		},
+	}
+
+	for i, tc := range testCases {
+		ckr := Run([]string{"-u", ts.URL, "-p", tc.regexp})
+		assert.Equal(t, ckr.Status, tc.status, "#%d: Status should be %s", i, tc.status)
+	}
+}
+
+func TestMaxRedirects(t *testing.T) {
+	redirectedPath := "/redirected"
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != redirectedPath {
+			http.Redirect(w, r, redirectedPath, 301)
+		}
+	}))
+	defer ts.Close()
+
+	testCases := []struct {
+		args []string
+		want checkers.Status
+	}{
+		{
+			args: []string{"-s", "301=ok", "-s", "100-300=warning", "-s", "302-599=warning",
+				"-u", ts.URL, "--max-redirects", "0"},
+			want: checkers.OK,
+		},
+		{
+			args: []string{"-s", "200=ok", "-s", "100-199=warning", "-s", "201-599=warning",
+				"-u", ts.URL, "--max-redirects", "1"},
+			want: checkers.OK,
+		},
+		{
+			args: []string{"-s", "200=ok", "-s", "100-199=warning", "-s", "201-599=warning",
+				"-u", ts.URL},
+			want: checkers.OK,
+		},
+	}
+
+	for i, tc := range testCases {
+		ckr := Run(tc.args)
+		assert.Equal(t, ckr.Status, tc.want, "#%d: Status should be %s", i, tc.want)
+	}
+}
+
+func TestConnectTos(t *testing.T) {
+	// expected server
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, "this is %s\n", r.URL.Host)
+	}))
+	defer ts.Close()
+	// extract host and port
+	s := strings.SplitN(ts.URL, ":", 3)
+	addr := strings.TrimPrefix(s[1], "//")
+	port := s[2]
+
+	// NON-expected server
+	ts2 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "wrong server!", 500)
+	}))
+	defer ts2.Close()
+	// extract host and port
+	s2 := strings.SplitN(ts.URL, ":", 3)
+	addr2 := strings.TrimPrefix(s2[1], "//")
+	port2 := s2[2]
+
+	testCases := []struct {
+		args []string
+		want checkers.Status
+	}{
+		{
+			// not affected at all
+			args: []string{"--connect-to", fmt.Sprintf("hoge:80:%s:%s", addr, port),
+				"-u", ts.URL},
+			want: checkers.OK,
+		},
+		{
+			// connected to target
+			args: []string{"--connect-to", fmt.Sprintf("hoge:80:%s:%s", addr, port),
+				"-u", "http://hoge"},
+			want: checkers.OK,
+		},
+		{
+			// empty srcHost means ANY
+			args: []string{"--connect-to", fmt.Sprintf(":80:%s:%s", addr, port),
+				"-u", "http://hoge"},
+			want: checkers.OK,
+		},
+		{
+			// empty srcPort means ANY
+			args: []string{"--connect-to", fmt.Sprintf("hoge::%s:%s", addr, port),
+				"-u", "http://hoge"},
+			want: checkers.OK,
+		},
+		{
+			// empty destHost means unchanged
+			args: []string{"--connect-to", fmt.Sprintf("%s:80::%s", addr, port),
+				"-u", fmt.Sprintf("http://%s", addr)},
+			want: checkers.OK,
+		},
+		{
+			// empty destPort means unchanged
+			args: []string{"--connect-to", fmt.Sprintf("hoge:%s:%s:", port, addr),
+				"-u", fmt.Sprintf("http://hoge:%s", port)},
+			want: checkers.OK,
+		},
+		{
+			// host mismatch ignored
+			args: []string{"--connect-to", fmt.Sprintf("not.target:%s:%s:%s", port, addr2, port2),
+				"-u", ts.URL},
+			want: checkers.OK,
+		},
+		{
+			// port mismatch ignored
+			args: []string{"--connect-to", fmt.Sprintf("%s:%s:%s:%s", addr, port2, addr2, port2),
+				"-u", ts.URL},
+			want: checkers.OK,
+		},
+		{
+			// host mismatch ignored, even if port is empty
+			args: []string{"--connect-to", fmt.Sprintf("not.target::%s:%s", addr2, port2),
+				"-u", ts.URL},
+			want: checkers.OK,
+		},
+		{
+			// port mismatch ignored, even if host is empty
+			args: []string{"--connect-to", fmt.Sprintf(":%s:%s:%s", port2, addr2, port2),
+				"-u", ts.URL},
+			want: checkers.OK,
+		},
+		{
+			// multiple setting (1)
+			args: []string{"--connect-to", fmt.Sprintf("not.hoge:80:%s:%s", addr2, port2),
+				"--connect-to", fmt.Sprintf("hoge:80:%s:%s", addr, port),
+				"-u", "http://hoge"},
+			want: checkers.OK,
+		},
+		{
+			// multiple setting (2)
+			args: []string{"--connect-to", fmt.Sprintf("hoge:80:%s:%s", addr, port),
+				"--connect-to", fmt.Sprintf("hoge:80:%s:%s", addr2, port2),
+				"-u", "http://hoge"},
+			want: checkers.OK,
+		},
+		{
+			// Invalid pattern
+			args: []string{"--connect-to", "foo:123:",
+				"-u", ts.URL},
+			want: checkers.UNKNOWN,
+		},
+	}
+
+	for i, tc := range testCases {
+		ckr := Run(tc.args)
+		assert.Equal(t, ckr.Status, tc.want, "#%d: Status should be %s, %s", i, tc.want, ckr.Message)
+	}
+}

--- a/check-json/main.go
+++ b/check-json/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/dbowling/go-check-plugins/check-json/lib"
+
+func main() {
+	checkjson.Do()
+}


### PR DESCRIPTION
This plugin is an adaptation of check-http that introduces JSON-specific checking.

- Validates the JSON document
- Accepts all the same options as check-http
- HTTP's regular expression option (`-p`, or `--pattern`) is then applied against an optional key lookup
- Key matching is done in dot notation (`$.obj`) according to [jsonslice](https://github.com/bhmj/jsonslice#expressions)

```
$ check-json --help
Usage:
  main [OPTIONS]

Application Options:
  -u, --url=                                  A URL to connect to
  -s, --status=                               mapping of HTTP status
      --no-check-certificate                  Do not check certificate
  -i, --source-ip=                            source IP address
  -H=                                         HTTP request headers
  -p, --pattern=EXPRESSION                    Expected regular expression pattern to compare value for selected key
      --max-redirects=                        Maximum number of redirects followed (default: 10)
      --connect-to=HOST1:PORT1:HOST2:PORT2    Request to HOST2:PORT2 instead of HOST1:PORT1
  -k, --key=EXPRESSION                        Limit value checks to JSON object key matching expression using https://github.com/bhmj/jsonslice#expressions (default: $)

Help Options:
  -h, --help                                  Show this help message
```

It's not ready to merge yet, but before I went to the trouble of refining it to match the standards in this project, I wanted to see if this was a a good way to introduce JSON features.

To do:
- [ ] Add test coverage
- [ ] Change import package in `main.go`
- [ ] Add documentation to README for use cases
- [ ] Add link in project's README
- [ ] Clean up `respMsg` formatting for consistency with check-http