### PR TITLE
[check-log]stop reading logs on SIGTERM

### DIFF
--- a/check-log/lib/check-log.go
+++ b/check-log/lib/check-log.go
@@ -122,7 +122,8 @@ func Do() {
 	defer cancel()
 	sigCh := make(chan os.Signal, 1)
 	go func() {
-		<-sigCh
+		sig := <-sigCh
+		log.Printf("check-log is exiting: caught a signal: %v", sig)
 		cancel()
 	}()
 	signal.Notify(sigCh, defaultSignal)

--- a/check-log/lib/check-log.go
+++ b/check-log/lib/check-log.go
@@ -240,6 +240,9 @@ func run(ctx context.Context, args []string) *checkers.Checker {
 }
 
 func (opts *logOpts) searchLog(ctx context.Context, logFile string) (int64, int64, string, error) {
+	if ctx.Err() != nil {
+		return 0, 0, "", nil
+	}
 	stateFile := getStateFile(opts.StateDir, logFile, opts.origArgs)
 	skipBytes, inode := int64(0), uint(0)
 	if !opts.NoState {

--- a/check-log/lib/check-log.go
+++ b/check-log/lib/check-log.go
@@ -182,6 +182,9 @@ func run(ctx context.Context, args []string) *checkers.Checker {
 	}
 
 	for _, f := range append(opts.fileListFromGlob, opts.fileListFromPattern...) {
+		if ctx.Err() != nil {
+			break
+		}
 		_, err := os.Stat(f)
 		if err != nil {
 			missingFiles = append(missingFiles, f)

--- a/check-log/lib/check-log_test.go
+++ b/check-log/lib/check-log_test.go
@@ -1,6 +1,7 @@
 package checklog
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -92,7 +93,7 @@ FATAL 22
 Fatal
 `
 	r := strings.NewReader(content)
-	warnNum, critNum, readBytes, errLines, err := opts.searchReader(r)
+	warnNum, critNum, readBytes, errLines, err := opts.searchReader(context.Background(), r)
 
 	assert.Equal(t, int64(2), warnNum, "warnNum should be 2")
 	assert.Equal(t, int64(2), critNum, "critNum should be 2")
@@ -121,7 +122,7 @@ func TestRun(t *testing.T) {
 	assert.Equal(t, int64(0), bytes, "something went wrong")
 
 	testEmpty := func() {
-		w, c, errLines, err := opts.searchLog(logf)
+		w, c, errLines, err := opts.searchLog(context.Background(), logf)
 		assert.Equal(t, err, nil, "err should be nil")
 		assert.Equal(t, int64(0), w, "something went wrong")
 		assert.Equal(t, int64(0), c, "something went wrong")
@@ -135,7 +136,7 @@ func TestRun(t *testing.T) {
 	lFirst := "FATAL\nFATAL\n"
 	test2Line := func() {
 		fh.WriteString(lFirst)
-		w, c, errLines, err := opts.searchLog(logf)
+		w, c, errLines, err := opts.searchLog(context.Background(), logf)
 		assert.Equal(t, err, nil, "err should be nil")
 		assert.Equal(t, int64(2), w, "something went wrong")
 		assert.Equal(t, int64(2), c, "something went wrong")
@@ -149,7 +150,7 @@ func TestRun(t *testing.T) {
 	l1 := "FATAL\nFATAL\nFATAL\n"
 	testReadAgain := func() {
 		fh.WriteString(l1)
-		w, c, errLines, err := opts.searchLog(logf)
+		w, c, errLines, err := opts.searchLog(context.Background(), logf)
 		assert.Equal(t, err, nil, "err should be nil")
 		assert.Equal(t, int64(3), w, "something went wrong")
 		assert.Equal(t, int64(3), c, "something went wrong")
@@ -163,7 +164,7 @@ func TestRun(t *testing.T) {
 	l2 := "SUCCESS\n"
 	testRecover := func() {
 		fh.WriteString(l2)
-		w, c, errLines, err := opts.searchLog(logf)
+		w, c, errLines, err := opts.searchLog(context.Background(), logf)
 		assert.Equal(t, err, nil, "err should be nil")
 		assert.Equal(t, int64(0), w, "something went wrong")
 		assert.Equal(t, int64(0), c, "something went wrong")
@@ -175,7 +176,7 @@ func TestRun(t *testing.T) {
 	testRecover()
 
 	testSuccessAgain := func() {
-		w, c, errLines, err := opts.searchLog(logf)
+		w, c, errLines, err := opts.searchLog(context.Background(), logf)
 		assert.Equal(t, err, nil, "err should be nil")
 		assert.Equal(t, int64(0), w, "something went wrong")
 		assert.Equal(t, int64(0), c, "something went wrong")
@@ -188,7 +189,7 @@ func TestRun(t *testing.T) {
 
 	testErrorAgain := func() {
 		fh.WriteString(l1)
-		w, c, errLines, err := opts.searchLog(logf)
+		w, c, errLines, err := opts.searchLog(context.Background(), logf)
 		assert.Equal(t, err, nil, "err should be nil")
 		assert.Equal(t, int64(3), w, "something went wrong")
 		assert.Equal(t, int64(3), c, "something went wrong")
@@ -201,7 +202,7 @@ func TestRun(t *testing.T) {
 
 	testRecoverAgain := func() {
 		fh.WriteString(l2)
-		w, c, errLines, err := opts.searchLog(logf)
+		w, c, errLines, err := opts.searchLog(context.Background(), logf)
 		assert.Equal(t, err, nil, "err should be nil")
 		assert.Equal(t, int64(0), w, "something went wrong")
 		assert.Equal(t, int64(0), c, "something went wrong")
@@ -218,7 +219,7 @@ func TestRun(t *testing.T) {
 		fh, _ = os.Create(logf)
 
 		fh.WriteString(l2)
-		w, c, errLines, err := opts.searchLog(logf)
+		w, c, errLines, err := opts.searchLog(context.Background(), logf)
 		assert.Equal(t, err, nil, "err should be nil")
 		assert.Equal(t, int64(0), w, "something went wrong")
 		assert.Equal(t, int64(0), c, "something went wrong")
@@ -251,7 +252,7 @@ func TestRunWithGlob(t *testing.T) {
 	opts.prepare()
 
 	testSuccess := func() {
-		ckr := run(params)
+		ckr := run(context.Background(), params)
 		assert.Equal(t, checkers.OK, ckr.Status, "ckr.Status should be OK")
 	}
 	testSuccess()
@@ -259,20 +260,20 @@ func TestRunWithGlob(t *testing.T) {
 	errorLine := "FATAL\n"
 	testCriticalOnce := func() {
 		fh1.WriteString(errorLine)
-		ckr := run(params)
+		ckr := run(context.Background(), params)
 		assert.Equal(t, checkers.CRITICAL, ckr.Status, "ckr.Status should be CRITICAL")
 	}
 	testCriticalOnce()
 
 	testRecover := func() {
-		ckr := run(params)
+		ckr := run(context.Background(), params)
 		assert.Equal(t, checkers.OK, ckr.Status, "ckr.Status should be OK")
 	}
 	testRecover()
 
 	testCriticalAgain := func() {
 		fh2.WriteString(errorLine)
-		ckr := run(params)
+		ckr := run(context.Background(), params)
 		assert.Equal(t, checkers.CRITICAL, ckr.Status, "ckr.Status should be CRITICAL")
 	}
 	testCriticalAgain()
@@ -305,7 +306,7 @@ func TestRunWithZGlob(t *testing.T) {
 	opts.prepare()
 
 	testSuccess := func() {
-		ckr := run(params)
+		ckr := run(context.Background(), params)
 		assert.Equal(t, checkers.OK, ckr.Status, "ckr.Status should be OK")
 	}
 	testSuccess()
@@ -313,20 +314,20 @@ func TestRunWithZGlob(t *testing.T) {
 	errorLine := "FATAL\n"
 	testCriticalOnce := func() {
 		fh1.WriteString(errorLine)
-		ckr := run(params)
+		ckr := run(context.Background(), params)
 		assert.Equal(t, checkers.CRITICAL, ckr.Status, "ckr.Status should be CRITICAL")
 	}
 	testCriticalOnce()
 
 	testRecover := func() {
-		ckr := run(params)
+		ckr := run(context.Background(), params)
 		assert.Equal(t, checkers.OK, ckr.Status, "ckr.Status should be OK")
 	}
 	testRecover()
 
 	testCriticalAgain := func() {
 		fh2.WriteString(errorLine)
-		ckr := run(params)
+		ckr := run(context.Background(), params)
 		assert.Equal(t, checkers.CRITICAL, ckr.Status, "ckr.Status should be CRITICAL")
 	}
 	testCriticalAgain()
@@ -355,7 +356,7 @@ func TestRunWithMiddleOfLine(t *testing.T) {
 
 	testMiddleOfLine := func() {
 		fh.WriteString("FATA")
-		w, c, errLines, err := opts.searchLog(logf)
+		w, c, errLines, err := opts.searchLog(context.Background(), logf)
 		assert.Equal(t, err, nil, "err should be nil")
 		assert.Equal(t, int64(0), w, "something went wrong")
 		assert.Equal(t, int64(0), c, "something went wrong")
@@ -368,7 +369,7 @@ func TestRunWithMiddleOfLine(t *testing.T) {
 
 	testFail := func() {
 		fh.WriteString("L\nSUCC")
-		w, c, errLines, err := opts.searchLog(logf)
+		w, c, errLines, err := opts.searchLog(context.Background(), logf)
 		assert.Equal(t, err, nil, "err should be nil")
 		assert.Equal(t, int64(1), w, "something went wrong")
 		assert.Equal(t, int64(1), c, "something went wrong")
@@ -399,7 +400,7 @@ func TestRunWithNoState(t *testing.T) {
 	test2Line := func() {
 		fh.WriteString(fatal)
 		fh.WriteString(fatal)
-		w, c, errLines, err := opts.searchLog(logf)
+		w, c, errLines, err := opts.searchLog(context.Background(), logf)
 		assert.Equal(t, err, nil, "err should be nil")
 		assert.Equal(t, int64(2), w, "something went wrong")
 		assert.Equal(t, int64(2), c, "something went wrong")
@@ -409,7 +410,7 @@ func TestRunWithNoState(t *testing.T) {
 
 	test1LineAgain := func() {
 		fh.WriteString(fatal)
-		w, c, errLines, err := opts.searchLog(logf)
+		w, c, errLines, err := opts.searchLog(context.Background(), logf)
 		assert.Equal(t, err, nil, "err should be nil")
 		assert.Equal(t, int64(3), w, "something went wrong")
 		assert.Equal(t, int64(3), c, "something went wrong")
@@ -451,7 +452,7 @@ FATAL level:22
 Fatal level:17
 `
 	r := strings.NewReader(content)
-	warnNum, critNum, readBytes, errLines, err := opts.searchReader(r)
+	warnNum, critNum, readBytes, errLines, err := opts.searchReader(context.Background(), r)
 
 	assert.Equal(t, int64(2), warnNum, "warnNum should be 2")
 	assert.Equal(t, int64(1), critNum, "critNum should be 1")
@@ -475,21 +476,21 @@ func TestRunWithEncoding(t *testing.T) {
 
 	testEncoding := func() {
 		fh.Write([]byte("\xa5\xa8\xa5\xe9\xa1\xbc\n")) // エラー
-		w, c, errLines, err := opts.searchLog(logf)
+		w, c, errLines, err := opts.searchLog(context.Background(), logf)
 		assert.Equal(t, err, nil, "err should be nil")
 		assert.Equal(t, int64(1), w, "something went wrong")
 		assert.Equal(t, int64(1), c, "something went wrong")
 		assert.Equal(t, "エラー\n", errLines, "something went wrong")
 
 		fh.Write([]byte("\xb0\xdb\xbe\xef\n")) // 異常
-		w, c, errLines, err = opts.searchLog(logf)
+		w, c, errLines, err = opts.searchLog(context.Background(), logf)
 		assert.Equal(t, err, nil, "err should be nil")
 		assert.Equal(t, int64(0), w, "something went wrong")
 		assert.Equal(t, int64(0), c, "something went wrong")
 		assert.Equal(t, "", errLines, "something went wrong")
 
 		fh.Write([]byte("\xa5\xa8\xa5\xe9\xa1\xbc\n")) // エラー
-		w, c, errLines, err = opts.searchLog(logf)
+		w, c, errLines, err = opts.searchLog(context.Background(), logf)
 		assert.Equal(t, err, nil, "err should be nil")
 		assert.Equal(t, int64(1), w, "something went wrong")
 		assert.Equal(t, int64(1), c, "something went wrong")
@@ -515,7 +516,7 @@ func TestRunWithoutEncoding(t *testing.T) {
 	fatal := "\xa5\xa8\xa5\xe9\xa1\xbc\nエラー\n" // エラー
 	testWithoutEncoding := func() {
 		fh.Write([]byte(fatal))
-		w, c, errLines, err := opts.searchLog(logf)
+		w, c, errLines, err := opts.searchLog(context.Background(), logf)
 		assert.Equal(t, err, nil, "err should be nil")
 		assert.Equal(t, int64(1), w, "something went wrong")
 		assert.Equal(t, int64(1), c, "something went wrong")
@@ -526,7 +527,7 @@ func TestRunWithoutEncoding(t *testing.T) {
 	fatal = "エラー\n"
 	testWithEncoding := func() {
 		fh.Write([]byte(fatal))
-		w, c, errLines, err := opts.searchLog(logf)
+		w, c, errLines, err := opts.searchLog(context.Background(), logf)
 		assert.Equal(t, err, nil, "err should be nil")
 		assert.Equal(t, int64(1), w, "something went wrong")
 		assert.Equal(t, int64(1), c, "something went wrong")
@@ -551,7 +552,7 @@ func TestRunWithMissingOk(t *testing.T) {
 	opts.prepare()
 
 	testRunLogFileMissing := func() {
-		ckr := run(params)
+		ckr := run(context.Background(), params)
 		assert.Equal(t, ckr.Status, checkers.OK, "ckr.Status should be OK")
 		msg := fmt.Sprintf("0 warnings, 0 criticals for pattern /FATAL/.\nThe following 1 files are missing.\n%s", logf)
 		assert.Equal(t, ckr.Message, msg, "something went wrong")
@@ -575,7 +576,7 @@ func TestRunWithMissingWarning(t *testing.T) {
 	opts.prepare()
 
 	testRunLogFileMissing := func() {
-		ckr := run(params)
+		ckr := run(context.Background(), params)
 		assert.Equal(t, ckr.Status, checkers.WARNING, "ckr.Status should be WARNING")
 		msg := fmt.Sprintf("0 warnings, 0 criticals for pattern /FATAL/.\nThe following 1 files are missing.\n%s", logf)
 		assert.Equal(t, ckr.Message, msg, "something went wrong")
@@ -599,7 +600,7 @@ func TestRunWithMissingCritical(t *testing.T) {
 	opts.prepare()
 
 	testRunLogFileMissing := func() {
-		ckr := run(params)
+		ckr := run(context.Background(), params)
 		assert.Equal(t, ckr.Status, checkers.CRITICAL, "ckr.Status should be CRITICAL")
 		msg := fmt.Sprintf("0 warnings, 0 criticals for pattern /FATAL/.\nThe following 1 files are missing.\n%s", logf)
 		assert.Equal(t, ckr.Message, msg, "something went wrong")
@@ -623,7 +624,7 @@ func TestRunWithMissingUnknown(t *testing.T) {
 	opts.prepare()
 
 	testRunLogFileMissing := func() {
-		ckr := run(params)
+		ckr := run(context.Background(), params)
 		assert.Equal(t, ckr.Status, checkers.UNKNOWN, "ckr.Status should be UNKNOWN")
 		msg := fmt.Sprintf("0 warnings, 0 criticals for pattern /FATAL/.\nThe following 1 files are missing.\n%s", logf)
 		assert.Equal(t, ckr.Message, msg, "something went wrong")
@@ -647,7 +648,7 @@ func TestRunWithGlobAndMissingWarning(t *testing.T) {
 	opts.prepare()
 
 	testRunLogFileMissing := func() {
-		ckr := run(params)
+		ckr := run(context.Background(), params)
 		assert.Equal(t, ckr.Status, checkers.WARNING, "ckr.Status should be WARNING")
 		msg := fmt.Sprintf("0 warnings, 0 criticals for pattern /FATAL/.\nThe following 1 files are missing.\n%s", logfGlob)
 		assert.Equal(t, ckr.Message, msg, "something went wrong")
@@ -680,7 +681,7 @@ func TestRunMultiplePattern(t *testing.T) {
 	l1 := "FATAL\nTESTAPPLICATION\n"
 	test2line := func() {
 		fh.WriteString(l1)
-		ckr := run(params)
+		ckr := run(context.Background(), params)
 		assert.Equal(t, checkers.OK, ckr.Status, "ckr.Status should be OK")
 		msg := "0 warnings, 0 criticals for pattern /FATAL/ and /TESTAPPLICATION/."
 		assert.Equal(t, ckr.Message, msg, "something went wrong")
@@ -693,7 +694,7 @@ func TestRunMultiplePattern(t *testing.T) {
 	l2 := "FATAL TESTAPPLICATION\nTESTAPPLICATION FATAL\n"
 	testAndCondition := func() {
 		fh.WriteString(l2)
-		ckr := run(params)
+		ckr := run(context.Background(), params)
 		assert.Equal(t, checkers.CRITICAL, ckr.Status, "ckr.Status should be CRITICAL")
 		msg := "2 warnings, 2 criticals for pattern /FATAL/ and /TESTAPPLICATION/."
 		assert.Equal(t, ckr.Message, msg, "something went wrong")
@@ -707,7 +708,7 @@ func TestRunMultiplePattern(t *testing.T) {
 	testWithLevel := func() {
 		fh.WriteString(l3)
 		params := []string{"-s", dir, "-f", logf, "-p", ptn1, "-p", ptn2, "--warning-level", "12"}
-		ckr := run(params)
+		ckr := run(context.Background(), params)
 		assert.Equal(t, checkers.UNKNOWN, ckr.Status, "ckr.Status should be UNKNOWN")
 		msg := "When multiple patterns specified, --warning-level --critical-level can not be used"
 		assert.Equal(t, ckr.Message, msg, "something went wrong")
@@ -718,7 +719,7 @@ func TestRunMultiplePattern(t *testing.T) {
 		fh.WriteString(l3)
 		ptn3 := "+"
 		params := []string{"-s", dir, "-f", logf, "-p", ptn1, "-p", ptn3}
-		ckr := run(params)
+		ckr := run(context.Background(), params)
 		assert.Equal(t, checkers.UNKNOWN, ckr.Status, "ckr.Status should be UNKNOWN")
 		msg := "pattern is invalid"
 		assert.Equal(t, ckr.Message, msg, "something went wrong")
@@ -751,7 +752,7 @@ func TestRunWithSuppressOption(t *testing.T) {
 	l1 := "FATAL\nTESTAPPLICATION\n"
 	test2line := func() {
 		fh.WriteString(l1)
-		ckr := run(params)
+		ckr := run(context.Background(), params)
 		assert.Equal(t, checkers.OK, ckr.Status, "ckr.Status should be OK")
 		msg := "0 warnings, 0 criticals."
 		assert.Equal(t, ckr.Message, msg, "something went wrong")
@@ -764,7 +765,7 @@ func TestRunWithSuppressOption(t *testing.T) {
 	l2 := "FATAL TESTAPPLICATION\nTESTAPPLICATION FATAL\n"
 	testAndCondition := func() {
 		fh.WriteString(l2)
-		ckr := run(params)
+		ckr := run(context.Background(), params)
 		assert.Equal(t, checkers.CRITICAL, ckr.Status, "ckr.Status should be CRITICAL")
 		msg := "2 warnings, 2 criticals."
 		assert.Equal(t, ckr.Message, msg, "something went wrong")
@@ -778,7 +779,7 @@ func TestRunWithSuppressOption(t *testing.T) {
 	testWithLevel := func() {
 		fh.WriteString(l3)
 		params := []string{"-s", dir, "-f", logf, "-p", ptn1, "-p", ptn2, "--warning-level", "12", "--suppress-pattern"}
-		ckr := run(params)
+		ckr := run(context.Background(), params)
 		assert.Equal(t, checkers.UNKNOWN, ckr.Status, "ckr.Status should be UNKNOWN")
 		msg := "When multiple patterns specified, --warning-level --critical-level can not be used"
 		assert.Equal(t, ckr.Message, msg, "something went wrong")
@@ -789,7 +790,7 @@ func TestRunWithSuppressOption(t *testing.T) {
 		fh.WriteString(l3)
 		ptn3 := "+"
 		params := []string{"-s", dir, "-f", logf, "-p", ptn1, "-p", ptn3, "--suppress-pattern"}
-		ckr := run(params)
+		ckr := run(context.Background(), params)
 		assert.Equal(t, checkers.UNKNOWN, ckr.Status, "ckr.Status should be UNKNOWN")
 		msg := "pattern is invalid"
 		assert.Equal(t, ckr.Message, msg, "something went wrong")

--- a/check-log/lib/check-log_test.go
+++ b/check-log/lib/check-log_test.go
@@ -233,6 +233,9 @@ func TestRun(t *testing.T) {
 	}
 	testRotate()
 
+	// Should test that check-log stops reading logs when timed out.
+	// If a period (10*time.Millisecond in below) is very short,
+	// normal behavior such as open a file, read it, etc could reach over a period.
 	opts.testHookNewBufferedReader = func(r io.Reader) *bufio.Reader {
 		return bufio.NewReaderSize(&slowReader{
 			r: r,

--- a/check-log/lib/check-log_unix.go
+++ b/check-log/lib/check-log_unix.go
@@ -7,6 +7,10 @@ import (
 	"syscall"
 )
 
+func init() {
+	defaultSignal = syscall.SIGTERM
+}
+
 func detectInode(fi os.FileInfo) uint {
 	if stat, ok := fi.Sys().(*syscall.Stat_t); ok {
 		return uint(stat.Ino)

--- a/check-log/lib/check-log_unix_test.go
+++ b/check-log/lib/check-log_unix_test.go
@@ -3,6 +3,7 @@
 package checklog
 
 import (
+	"context"
 	"io"
 	"io/ioutil"
 	"os"
@@ -128,7 +129,7 @@ func TestRunTraceInode(t *testing.T) {
 	testRotate := func() {
 		// first check
 		fh.WriteString(l1)
-		opts.searchLog(logf)
+		opts.searchLog(context.Background(), logf)
 
 		// write FATAL
 		fh.WriteString(l2)
@@ -141,7 +142,7 @@ func TestRunTraceInode(t *testing.T) {
 
 		fh.WriteString(l3)
 		// second check
-		w, c, errLines, err := opts.searchLog(logf)
+		w, c, errLines, err := opts.searchLog(context.Background(), logf)
 		assert.Equal(t, err, nil, "err should be nil")
 		assert.Equal(t, int64(1), w, "something went wrong")
 		assert.Equal(t, int64(1), c, "something went wrong")
@@ -159,7 +160,7 @@ func TestRunTraceInode(t *testing.T) {
 	testRotateDifferentDir := func() {
 		// first check
 		fh.WriteString(l1)
-		opts.searchLog(logf)
+		opts.searchLog(context.Background(), logf)
 
 		// write FATAL
 		fh.WriteString(l2)
@@ -174,7 +175,7 @@ func TestRunTraceInode(t *testing.T) {
 
 		fh.WriteString(l3)
 		// second check
-		w, c, errLines, err := opts.searchLog(logf)
+		w, c, errLines, err := opts.searchLog(context.Background(), logf)
 		assert.Equal(t, err, nil, "err should be nil when the old file is not found")
 		assert.Equal(t, int64(0), w, "something went wrong")
 		assert.Equal(t, int64(0), c, "something went wrong")


### PR DESCRIPTION
I added signal handler to check-log plugin to catch timeout from mackerel-agent.

When *check-log* plugin catches SIGTERM (Unix) or `os.Interrupt` (Windows), the plugin will read bytes until next newline and stop reading logs, and respond result to Mackerel.