### PR TITLE
 [check-log][check-windows-eventlog] Improve atomic write

### DIFF
--- a/check-log/lib/check-log_test.go
+++ b/check-log/lib/check-log_test.go
@@ -63,7 +63,7 @@ func TestGetBytesToSkip(t *testing.T) {
 	newf := ".tmp/fuga/piyo.json"
 	state := &state{SkipBytes: 15}
 	os.MkdirAll(filepath.Dir(oldf), 0755)
-	writeFileAtomically(oldf, []byte(fmt.Sprintf("%d", state.SkipBytes)))
+	ioutil.WriteFile(oldf, []byte(fmt.Sprintf("%d", state.SkipBytes)), 0600)
 	defer os.RemoveAll(".tmp")
 
 	n, err := getBytesToSkip(newf)

--- a/check-windows-eventlog/lib/check-windows-eventlog.go
+++ b/check-windows-eventlog/lib/check-windows-eventlog.go
@@ -23,6 +23,7 @@ import (
 	"github.com/mackerelio/checkers"
 	"github.com/mackerelio/go-check-plugins/check-windows-eventlog/lib/internal/eventlog"
 	"github.com/mackerelio/golib/pluginutil"
+	"github.com/natefinch/atomic"
 )
 
 const (
@@ -532,5 +533,5 @@ func writeLastOffset(f string, num int64) error {
 	if err != nil {
 		return err
 	}
-	return ioutil.WriteFile(f, []byte(fmt.Sprintf("%d", num)), 0644)
+	return atomic.WriteFile(f, strings.NewReader(fmt.Sprintf("%d", num)))
 }


### PR DESCRIPTION
This pull request introduces https://github.com/natefinch/atomic library. The library is simple enough and fixes the problem os.Rename is not atomic on Windows. Also reduces one remove call compared to our writeFileAtomically function.