### PR TITLE
[check-http] add --proxy option

### DIFF
--- a/check-http/README.md
+++ b/check-http/README.md
@@ -73,6 +73,7 @@ To request via proxy (http/https/socks5)
 ```shell
 check-http --proxy=http://localhost:8080 -u http://example.com # request via http://localhost:8080
 HTTP_PROXY=http://localhost:8080 check-http  -u http://example.com # Same. you can set proxy via environment variable
+check-http --proxy=http://user:pass@localhost:8080 -u http://example.com # basic authentication is also supported
 ```
 ## For more information
 

--- a/check-http/README.md
+++ b/check-http/README.md
@@ -50,6 +50,7 @@ command = ["check-http", "-u", "http://example.com"]
   -p, --pattern=                              Expected pattern in the content
       --max-redirects=                        Maximum number of redirects followed (default: 10)
       --connect-to=HOST1:PORT1:HOST2:PORT2    Request to HOST2:PORT2 instead of HOST1:PORT1
+  -x, --proxy=[PROTOCOL://]HOST[:PORT]        Use the specified proxy. PROTOCOL's default is http, and PORT's default is 1080.
 ```
 
 
@@ -68,6 +69,11 @@ check-http --connect-to=localhost:443::8080 https://localhost # empty host2 mean
 check-http --connect-to=example.com:443:127.0.0.1: https://example.com # empty port2 means unchanged, therefore will request to 127.0.0.1:443
 ```
 
+To request via proxy (http/https/socks5)
+```shell
+check-http --proxy=http://localhost:8080 -u http://example.com # request via http://localhost:8080
+HTTP_PROXY=http://localhost:8080 check-http  -u http://example.com # Same. you can set proxy via environment variable
+```
 ## For more information
 
 Please execute `check-http -h` and you can get command line options.

--- a/check-http/README.md
+++ b/check-http/README.md
@@ -42,15 +42,15 @@ command = ["check-http", "-u", "http://example.com"]
 ### Options
 
 ```
-  -u, --url=                                  A URL to connect to
-  -s, --status=                               mapping of HTTP status
-      --no-check-certificate                  Do not check certificate
-  -i, --source-ip=                            source IP address
-  -H=                                         HTTP request headers
-  -p, --pattern=                              Expected pattern in the content
-      --max-redirects=                        Maximum number of redirects followed (default: 10)
-      --connect-to=HOST1:PORT1:HOST2:PORT2    Request to HOST2:PORT2 instead of HOST1:PORT1
-  -x, --proxy=[PROTOCOL://]HOST[:PORT]        Use the specified proxy. PROTOCOL's default is http, and PORT's default is 1080.
+  -u, --url=                                          A URL to connect to
+  -s, --status=                                       mapping of HTTP status
+      --no-check-certificate                          Do not check certificate
+  -i, --source-ip=                                    source IP address
+  -H=                                                 HTTP request headers
+  -p, --pattern=                                      Expected pattern in the content
+      --max-redirects=                                Maximum number of redirects followed (default: 10)
+      --connect-to=HOST1:PORT1:HOST2:PORT2            Request to HOST2:PORT2 instead of HOST1:PORT1
+  -x, --proxy=[PROTOCOL://][USER:PASS@]HOST[:PORT]    Use the specified proxy. PROTOCOL's default is http, and PORT's default is 1080.
 ```
 
 

--- a/check-http/lib/check_http.go
+++ b/check-http/lib/check_http.go
@@ -31,7 +31,7 @@ type checkHTTPOpts struct {
 	Regexp             string   `short:"p" long:"pattern" description:"Expected pattern in the content"`
 	MaxRedirects       int      `long:"max-redirects" description:"Maximum number of redirects followed" default:"10"`
 	ConnectTos         []string `long:"connect-to" value-name:"HOST1:PORT1:HOST2:PORT2" description:"Request to HOST2:PORT2 instead of HOST1:PORT1"`
-	Proxy              string   `short:"x" long:"proxy" value-name:"[PROTOCOL://]HOST[:PORT]" description:"Use the specified proxy. PROTOCOL's default is http, and PORT's default is 1080."`
+	Proxy              string   `short:"x" long:"proxy" value-name:"[PROTOCOL://][USER:PASS@]HOST[:PORT]" description:"Use the specified proxy. PROTOCOL's default is http, and PORT's default is 1080."`
 }
 
 // Do the plugin

--- a/check-http/lib/check_http.go
+++ b/check-http/lib/check_http.go
@@ -180,7 +180,8 @@ func parseProxy(opts *checkHTTPOpts) (*url.URL, error) {
 	if opts.Proxy == "" {
 		return nil, nil
 	}
-	// url.Parse cannot parse hostname:port, so append protocol if absent
+	// Append protocol if absent.
+	// Overwriting u.Scheme is not enough, since url.Parse cannot parse "HOST:PORT" since it's ambiguous
 	proxy := opts.Proxy
 	if !strings.Contains(proxy, "://") {
 		proxy = "http://" + proxy
@@ -189,10 +190,6 @@ func parseProxy(opts *checkHTTPOpts) (*url.URL, error) {
 	if err != nil {
 		return nil, err
 	}
-	// if u.Scheme == "" {
-	// 	// http.Transport treats empty scheme as http, but fill scheme here explicitly
-	// 	u.Scheme = "http"
-	// }
 	if u.Port() == "" {
 		u.Host = u.Hostname() + ":1080"
 	}

--- a/check-http/lib/check_http.go
+++ b/check-http/lib/check_http.go
@@ -229,12 +229,12 @@ func Run(args []string) *checkers.Checker {
 		dialer.LocalAddr = &net.TCPAddr{IP: ip}
 	}
 
-	proxyUrl, err := parseProxy(&opts)
+	proxyURL, err := parseProxy(&opts)
 	if err != nil {
 		return checkers.Unknown(err.Error())
 	}
-	if proxyUrl != nil {
-		tr.Proxy = http.ProxyURL(proxyUrl)
+	if proxyURL != nil {
+		tr.Proxy = http.ProxyURL(proxyURL)
 	}
 
 	if len(opts.ConnectTos) != 0 {

--- a/check-http/lib/check_http_test.go
+++ b/check-http/lib/check_http_test.go
@@ -373,7 +373,7 @@ func TestProxy_Auth(t *testing.T) {
 			want: checkers.OK,
 		},
 		{
-			//
+			// with basic => pass
 			args: []string{"--proxy", "http://somename:somepassword@" + hostPort,
 				"--pattern", fmt.Sprintf("intercept a req to %s", ts.URL),
 				"-u", ts.URL},


### PR DESCRIPTION
Although check-http can request using proxy via `HTTP_PROXY` environment variable, imo it's useful when we can specify the proxy url from command line option.
