### PR TITLE
check-gateway: uses arping to check a gateway

### DIFF
--- a/check-gateway/README.md
+++ b/check-gateway/README.md
@@ -1,0 +1,35 @@
+# check-gateway
+
+## Description
+
+Check ICMP Ping connections with the specified host forcing a specified gateway
+
+Depends on arping-th
+
+## Synopsis
+```
+check-gateway -H 1.1.1.1 -I eth0 192.168.1.1
+```
+
+## Installation
+
+First, build this program.
+
+```
+go get github.com/mackerelio/go-check-plugins
+cd $(go env GOPATH)/src/github.com/mackerelio/go-check-plugins/check-gateway
+go install
+```
+
+If you are ok running it as root, you are done!
+
+If you want to run as user, set it setuid root. Probably `setcap` can be enough on Linux, I just haven't had
+time to test it.
+
+
+## Usage
+### Options
+
+## For more information
+
+Please execute `check-gateway -h` and you can get command line options.

--- a/check-gateway/lib/check-gateway.go
+++ b/check-gateway/lib/check-gateway.go
@@ -1,0 +1,110 @@
+package checkgateway
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"os/exec"
+	"regexp"
+	"strconv"
+	"strings"
+
+	flags "github.com/jessevdk/go-flags"
+	"github.com/mackerelio/checkers"
+)
+
+var opts struct {
+	Host      string `long:"host" short:"H" description:"check target IP Address" required:"true"`
+	Gateway   string `long:"gateway" short:"g" description:"gateway MAC or IP or name" required:"true"`
+	Count     int    `long:"count" short:"n" default:"1" description:"sending (and receiving) count ping packets"`
+	Interface string `long:"interface" short:"I" description:"the interface on which the packets must be sent"`
+
+	Thresholds struct {
+		WarningLoss  int `long:"warning" short:"w" default:"30" description:"maximum percentage of allowed data loss"`
+		CriticalLoss int `long:"critical" short:"c" default:"80"`
+	} `group:"Tuning thresholds"`
+
+	Paths struct {
+		Arping string `long:"arping-path" default:"arping"`
+		Arp    string `long:"arp-path" default:"arp"`
+	} `group:"Binaries paths"`
+}
+
+func resolveIP(ip string) (string, error) {
+	out, err := exec.Command(opts.Paths.Arp, ip).Output()
+	if err != nil {
+		return "", err
+	}
+	macre := regexp.MustCompile("..:..:..:..:..:..")
+	if !macre.Match(out) {
+		return "", fmt.Errorf("cannot find mac address for %s", ip)
+	}
+	return macre.FindString(string(out)), nil
+}
+
+func run(args []string) *checkers.Checker {
+	var parser = flags.NewParser(&opts, flags.Default)
+	_, err := parser.ParseArgs(args)
+	if err != nil {
+		os.Exit(1)
+	}
+	if opts.Host == "" {
+		parser.WriteHelp(os.Stderr)
+		os.Exit(1)
+	}
+
+	if !strings.Contains(opts.Gateway, ":") {
+		ra, err := net.ResolveIPAddr("ip4", opts.Gateway)
+		if err != nil {
+			return checkers.Critical("Could not resolve host")
+		}
+		ip := ra.IP.String()
+		mac, err := resolveIP(ip)
+		if err != nil {
+			return checkers.Critical("Could not resolve IP")
+		}
+		opts.Gateway = mac
+	}
+	cmdArgs := []string{"-c", strconv.Itoa(opts.Count),
+		"-T",
+		opts.Host}
+	if len(opts.Interface) > 0 {
+		cmdArgs = append(cmdArgs, "-I", opts.Interface)
+	}
+	cmdArgs = append(cmdArgs, opts.Gateway)
+
+	cmd := exec.Command(opts.Paths.Arping, cmdArgs...)
+	out, err := cmd.Output()
+
+	if err != nil {
+		fmt.Println(string(out))
+		return checkers.Critical(err.Error())
+	}
+	outs := strings.Split(string(out), "\n")
+	stats := outs[len(outs)-3]
+	// TODO: times := outs[len(outs)-2]
+
+	re := regexp.MustCompile(`(\d+)%`)
+	if !re.MatchString(stats) || len(re.FindStringSubmatch(stats)) < 2 {
+		return checkers.Critical("error parsing arping output")
+	}
+	perc, err := strconv.Atoi(re.FindStringSubmatch(stats)[1])
+	if err != nil {
+		return checkers.Critical("error parsing arping output: non-integer percentage found")
+	}
+	explaination := fmt.Sprintf("lost=%d%%", perc)
+	if perc > opts.Thresholds.CriticalLoss {
+		return checkers.Critical(explaination)
+	}
+	if perc > opts.Thresholds.WarningLoss {
+		return checkers.Warning(explaination)
+	}
+	return checkers.Ok(explaination)
+}
+
+// Do the plugin
+func Do() {
+	ckr := run(os.Args[1:])
+	ckr.Name = "Gateway"
+	ckr.Exit()
+}

--- a/check-gateway/main.go
+++ b/check-gateway/main.go
@@ -1,0 +1,7 @@
+package main
+
+import checkgateway "github.com/mackerelio/go-check-plugins/check-gateway/lib"
+
+func main() {
+	checkgateway.Do()
+}


### PR DESCRIPTION
this PR adds a new check command.

It works calling both `arp` and `arping` commands. In the near future I plan to improve it, removing the need for the `arp` command (which is very system-dependent).

There are many implementations of `arping`: the one that this plugin requires is `arping-th` (package `arping` on ubuntu)