### PR TITLE
[check-procs] If more than one pattern is specified, find processes that meet any of the conditions.

### DIFF
--- a/check-procs/lib/check_procs.go
+++ b/check-procs/lib/check_procs.go
@@ -20,7 +20,7 @@ var opts struct {
 	CritUnder     int64    `short:"C" long:"critical-under" value-name:"N" default:"1" description:"Trigger a critial if under a number"`
 	MatchSelf     bool     `short:"m" long:"match-self" description:"Match itself"`
 	MatchParent   bool     `short:"M" long:"match-parent" description:"Match parent"`
-	CmdPat        []string `short:"p" long:"pattern" value-name:"PATTERN" description:"Match a command against this pattern"`
+	CmdPatterns   []string `short:"p" long:"pattern" value-name:"PATTERN" description:"Match a command against these patterns"`
 	CmdExcludePat string   `short:"x" long:"exclude-pattern" value-name:"PATTERN" description:"Don't match against a pattern to prevent false positives"`
 	Ppid          string   `long:"ppid" value-name:"PPID" description:"Check against a specific PPID"`
 	FilePid       string   `short:"f" long:"file-pid" value-name:"PID" description:"Check against a specific PID"`
@@ -77,7 +77,7 @@ func run(args []string) *checkers.Checker {
 		return checkers.NewChecker(checkers.UNKNOWN, err.Error())
 	}
 	var cmdPatRegexp []*regexp.Regexp
-	for _, ptn := range opts.CmdPat {
+	for _, ptn := range opts.CmdPatterns {
 		r, err := regexp.Compile(ptn)
 		if err != nil {
 			return checkers.NewChecker(checkers.UNKNOWN, err.Error())
@@ -114,7 +114,7 @@ func run(args []string) *checkers.Checker {
 }
 
 func matchProc(proc procState, cmdPatRegexp *regexp.Regexp, cmdExcludePatRegexp *regexp.Regexp) bool {
-	return (len(opts.CmdPat) == 0 || cmdPatRegexp.MatchString(proc.cmd)) &&
+	return (len(opts.CmdPatterns) == 0 || cmdPatRegexp.MatchString(proc.cmd)) &&
 		(opts.CmdExcludePat == "" || !cmdExcludePatRegexp.MatchString(proc.cmd)) &&
 		(opts.MatchSelf || proc.pid != strconv.Itoa(os.Getpid())) &&
 		(opts.MatchParent || proc.pid != strconv.Itoa(os.Getppid())) &&
@@ -135,7 +135,7 @@ func matchProc(proc procState, cmdPatRegexp *regexp.Regexp, cmdExcludePatRegexp 
 
 func gatherMsg(count int64, pattern string) string {
 	msg := fmt.Sprintf("Found %d matching processes", count)
-	if len(opts.CmdPat) != 0 {
+	if len(opts.CmdPatterns) != 0 {
 		msg += fmt.Sprintf("; cmd /%s/", pattern)
 	}
 	if opts.State != "" {

--- a/check-procs/lib/check_procs.go
+++ b/check-procs/lib/check_procs.go
@@ -12,29 +12,29 @@ import (
 
 // https://github.com/sensu-plugins/sensu-plugins-process-checks
 var opts struct {
-	WarningOver   *int64  `short:"w" long:"warning-over" value-name:"N" description:"Trigger a warning if over a number"`
-	WarnOver      *int64  `long:"warn-over" value-name:"N" description:"(DEPRECATED) Trigger a warning if over a number"`
-	CritOver      *int64  `short:"c" long:"critical-over" value-name:"N" description:"Trigger a critical if over a number"`
-	WarningUnder  int64   `short:"W" long:"warning-under" value-name:"N" default:"1" description:"Trigger a warning if under a number"`
-	WarnUnder     int64   `long:"warn-under" value-name:"N" default:"1" description:"(DEPRECATED) Trigger a warning if under a number"`
-	CritUnder     int64   `short:"C" long:"critical-under" value-name:"N" default:"1" description:"Trigger a critial if under a number"`
-	MatchSelf     bool    `short:"m" long:"match-self" description:"Match itself"`
-	MatchParent   bool    `short:"M" long:"match-parent" description:"Match parent"`
-	CmdPat        string  `short:"p" long:"pattern" value-name:"PATTERN" description:"Match a command against this pattern"`
-	CmdExcludePat string  `short:"x" long:"exclude-pattern" value-name:"PATTERN" description:"Don't match against a pattern to prevent false positives"`
-	Ppid          string  `long:"ppid" value-name:"PPID" description:"Check against a specific PPID"`
-	FilePid       string  `short:"f" long:"file-pid" value-name:"PID" description:"Check against a specific PID"`
-	Vsz           int64   `short:"z" long:"virtual-memory-size" value-name:"VSZ" description:"Trigger on a Virtual Memory size is bigger than this"`
-	Rss           int64   `short:"r" long:"resident-set-size" value-name:"RSS" description:"Trigger on a Resident Set size is bigger than this"`
-	Pcpu          float64 `short:"P" long:"proportional-set-size" value-name:"PCPU" description:"Trigger on a Proportional Set Size is bigger than this"`
-	Thcount       int64   `short:"T" long:"thread-count" value-name:"THCOUNT" description:"Trigger on a Thread Count is bigger than this"`
-	State         string  `short:"s" long:"state" value-name:"STATE" description:"Trigger on a specific state, example: Z for zombie"`
-	User          string  `short:"u" long:"user" value-name:"USER" description:"Trigger on a specific user"`
-	Usernot       string  `short:"U" long:"user-not" value-name:"USER" description:"Trigger if not owned a specific user"`
-	EsecOver      int64   `short:"e" long:"esec-over" value-name:"SECONDS" description:"Match processes that older that this, in SECONDS"`
-	EsecUnder     int64   `short:"E" long:"esec-under" value-name:"SECONDS" description:"Match process that are younger than this, in SECONDS"`
-	CPUOver       int64   `short:"i" long:"cpu-over" value-name:"SECONDS" description:"Match processes cpu time that is older than this, in SECONDS"`
-	CPUUnder      int64   `short:"I" long:"cpu-under" value-name:"SECONDS" description:"Match processes cpu time that is younger than this, in SECONDS"`
+	WarningOver   *int64   `short:"w" long:"warning-over" value-name:"N" description:"Trigger a warning if over a number"`
+	WarnOver      *int64   `long:"warn-over" value-name:"N" description:"(DEPRECATED) Trigger a warning if over a number"`
+	CritOver      *int64   `short:"c" long:"critical-over" value-name:"N" description:"Trigger a critical if over a number"`
+	WarningUnder  int64    `short:"W" long:"warning-under" value-name:"N" default:"1" description:"Trigger a warning if under a number"`
+	WarnUnder     int64    `long:"warn-under" value-name:"N" default:"1" description:"(DEPRECATED) Trigger a warning if under a number"`
+	CritUnder     int64    `short:"C" long:"critical-under" value-name:"N" default:"1" description:"Trigger a critial if under a number"`
+	MatchSelf     bool     `short:"m" long:"match-self" description:"Match itself"`
+	MatchParent   bool     `short:"M" long:"match-parent" description:"Match parent"`
+	CmdPat        []string `short:"p" long:"pattern" value-name:"PATTERN" description:"Match a command against this pattern"`
+	CmdExcludePat string   `short:"x" long:"exclude-pattern" value-name:"PATTERN" description:"Don't match against a pattern to prevent false positives"`
+	Ppid          string   `long:"ppid" value-name:"PPID" description:"Check against a specific PPID"`
+	FilePid       string   `short:"f" long:"file-pid" value-name:"PID" description:"Check against a specific PID"`
+	Vsz           int64    `short:"z" long:"virtual-memory-size" value-name:"VSZ" description:"Trigger on a Virtual Memory size is bigger than this"`
+	Rss           int64    `short:"r" long:"resident-set-size" value-name:"RSS" description:"Trigger on a Resident Set size is bigger than this"`
+	Pcpu          float64  `short:"P" long:"proportional-set-size" value-name:"PCPU" description:"Trigger on a Proportional Set Size is bigger than this"`
+	Thcount       int64    `short:"T" long:"thread-count" value-name:"THCOUNT" description:"Trigger on a Thread Count is bigger than this"`
+	State         string   `short:"s" long:"state" value-name:"STATE" description:"Trigger on a specific state, example: Z for zombie"`
+	User          string   `short:"u" long:"user" value-name:"USER" description:"Trigger on a specific user"`
+	Usernot       string   `short:"U" long:"user-not" value-name:"USER" description:"Trigger if not owned a specific user"`
+	EsecOver      int64    `short:"e" long:"esec-over" value-name:"SECONDS" description:"Match processes that older that this, in SECONDS"`
+	EsecUnder     int64    `short:"E" long:"esec-under" value-name:"SECONDS" description:"Match process that are younger than this, in SECONDS"`
+	CPUOver       int64    `short:"i" long:"cpu-over" value-name:"SECONDS" description:"Match processes cpu time that is older than this, in SECONDS"`
+	CPUUnder      int64    `short:"I" long:"cpu-under" value-name:"SECONDS" description:"Match processes cpu time that is younger than this, in SECONDS"`
 }
 
 type procState struct {
@@ -76,13 +76,16 @@ func run(args []string) *checkers.Checker {
 	if err != nil {
 		return checkers.NewChecker(checkers.UNKNOWN, err.Error())
 	}
-	cmdPatRegexp := regexp.MustCompile(".*")
-	if opts.CmdPat != "" {
-		r, err := regexp.Compile(opts.CmdPat)
+	var cmdPatRegexp []*regexp.Regexp
+	for _, ptn := range opts.CmdPat {
+		r, err := regexp.Compile(ptn)
 		if err != nil {
 			return checkers.NewChecker(checkers.UNKNOWN, err.Error())
 		}
-		cmdPatRegexp = r
+		cmdPatRegexp = append(cmdPatRegexp, r)
+	}
+	if len(cmdPatRegexp) == 0 {
+		cmdPatRegexp = append(cmdPatRegexp, regexp.MustCompile(".*"))
 	}
 	cmdExcludePatRegexp := regexp.MustCompile(".*")
 	if opts.CmdExcludePat != "" {
@@ -92,27 +95,26 @@ func run(args []string) *checkers.Checker {
 		}
 		cmdExcludePatRegexp = r
 	}
-	var resultrocStates []procState
-	for _, proc := range procs {
-		if matchProc(proc, cmdPatRegexp, cmdExcludePatRegexp) {
-			resultrocStates = append(resultrocStates, proc)
-		}
-	}
-	count := int64(len(resultrocStates))
-	msg := gatherMsg(count)
 	result := checkers.OK
-	if opts.CritUnder != 0 && count < opts.CritUnder ||
-		opts.CritOver != nil && count > *opts.CritOver {
-		result = checkers.CRITICAL
-	} else if opts.WarningUnder != 0 && count < opts.WarningUnder ||
-		opts.WarningOver != nil && count > *opts.WarningOver {
-		result = checkers.WARNING
+	var msg string
+	var resultrocStates []procState
+	for _, reg := range cmdPatRegexp {
+		for _, proc := range procs {
+			if matchProc(proc, reg, cmdExcludePatRegexp) {
+				resultrocStates = append(resultrocStates, proc)
+			}
+		}
+		count := int64(len(resultrocStates))
+		result = optimizeStatus(count, result)
+		msg += fmt.Sprintf("\n%s", gatherMsg(count, reg.String()))
+
+		resultrocStates = []procState{}
 	}
 	return checkers.NewChecker(result, msg)
 }
 
 func matchProc(proc procState, cmdPatRegexp *regexp.Regexp, cmdExcludePatRegexp *regexp.Regexp) bool {
-	return (opts.CmdPat == "" || cmdPatRegexp.MatchString(proc.cmd)) &&
+	return (len(opts.CmdPat) == 0 || cmdPatRegexp.MatchString(proc.cmd)) &&
 		(opts.CmdExcludePat == "" || !cmdExcludePatRegexp.MatchString(proc.cmd)) &&
 		(opts.MatchSelf || proc.pid != strconv.Itoa(os.Getpid())) &&
 		(opts.MatchParent || proc.pid != strconv.Itoa(os.Getppid())) &&
@@ -131,10 +133,10 @@ func matchProc(proc procState, cmdPatRegexp *regexp.Regexp, cmdExcludePatRegexp 
 		(opts.CPUOver == 0 || proc.csec > opts.CPUOver)
 }
 
-func gatherMsg(count int64) string {
+func gatherMsg(count int64, pattern string) string {
 	msg := fmt.Sprintf("Found %d matching processes", count)
-	if opts.CmdPat != "" {
-		msg += fmt.Sprintf("; cmd /%s/", opts.CmdPat)
+	if len(opts.CmdPat) != 0 {
+		msg += fmt.Sprintf("; cmd /%s/", pattern)
 	}
 	if opts.State != "" {
 		msg += fmt.Sprintf("; state /%s/", opts.State)
@@ -176,4 +178,23 @@ func gatherMsg(count int64) string {
 		msg += fmt.Sprintf("; pid %s", opts.FilePid)
 	}
 	return msg
+}
+
+func optimizeStatus(count int64, current checkers.Status) checkers.Status {
+	result := checkers.OK
+	if opts.CritUnder != 0 && count < opts.CritUnder ||
+		opts.CritOver != nil && count > *opts.CritOver {
+		result = checkers.CRITICAL
+	} else if opts.WarningUnder != 0 && count < opts.WarningUnder ||
+		opts.WarningOver != nil && count > *opts.WarningOver {
+		result = checkers.WARNING
+	}
+
+	if result > checkers.WARNING {
+		return checkers.CRITICAL
+	} else if result > checkers.OK {
+		return checkers.WARNING
+	} else {
+		return checkers.OK
+	}
 }

--- a/check-procs/lib/check_procs.go
+++ b/check-procs/lib/check_procs.go
@@ -105,7 +105,7 @@ func run(args []string) *checkers.Checker {
 			}
 		}
 		count := int64(len(resultrocStates))
-		result = optimizeStatus(count, result)
+		result = mergeStatus(count, result)
 		msg += fmt.Sprintf("\n%s", gatherMsg(count, reg.String()))
 
 		resultrocStates = []procState{}
@@ -180,7 +180,7 @@ func gatherMsg(count int64, pattern string) string {
 	return msg
 }
 
-func optimizeStatus(count int64, current checkers.Status) checkers.Status {
+func mergeStatus(count int64, current checkers.Status) checkers.Status {
 	result := checkers.OK
 	if opts.CritUnder != 0 && count < opts.CritUnder ||
 		opts.CritOver != nil && count > *opts.CritOver {

--- a/check-procs/lib/check_procs.go
+++ b/check-procs/lib/check_procs.go
@@ -97,6 +97,7 @@ func run(args []string) *checkers.Checker {
 	}
 	result := checkers.OK
 	var msg string
+
 	var resultrocStates []procState
 	for _, reg := range cmdPatRegexp {
 		for _, proc := range procs {

--- a/check-procs/lib/check_procs_test.go
+++ b/check-procs/lib/check_procs_test.go
@@ -1,6 +1,7 @@
 package checkprocs
 
 import (
+	"fmt"
 	"runtime"
 	"testing"
 
@@ -66,4 +67,14 @@ func TestOptimizeStatus(t *testing.T) {
 	assert.Equal(t, checkers.WARNING, optimizeStatus(39, checkers.OK))
 	assert.Equal(t, checkers.WARNING, optimizeStatus(10, checkers.OK))
 	assert.Equal(t, checkers.CRITICAL, optimizeStatus(9, checkers.OK))
+}
+
+func TestGatherMsg(t *testing.T) {
+	var count int64 = 1
+	opts.CmdPat = []string{"foo", "bar"}
+
+	for _, pattern := range opts.CmdPat {
+		expected := fmt.Sprintf("Found %d matching processes; cmd /%s/", count, pattern)
+		assert.Equal(t, expected, gatherMsg(count, pattern))
+	}
 }

--- a/check-procs/lib/check_procs_test.go
+++ b/check-procs/lib/check_procs_test.go
@@ -3,6 +3,9 @@ package checkprocs
 import (
 	"runtime"
 	"testing"
+
+	"github.com/mackerelio/checkers"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestProcs(t *testing.T) {
@@ -42,4 +45,25 @@ func TestProcs(t *testing.T) {
 			t.Fatal("csec should not be 0")
 		}
 	}
+}
+
+func TestOptimizeStatus(t *testing.T) {
+	var CritOver int64 = 100
+	var WarningOver int64 = 80
+	var WarningUnder int64 = 40
+	var CritUnder int64 = 10
+
+	opts.CritOver = &CritOver
+	opts.WarningOver = &WarningOver
+	opts.WarningUnder = WarningUnder
+	opts.CritUnder = CritUnder
+
+	assert.Equal(t, checkers.OK, optimizeStatus(80, checkers.OK))
+	assert.Equal(t, checkers.WARNING, optimizeStatus(81, checkers.OK))
+	assert.Equal(t, checkers.WARNING, optimizeStatus(100, checkers.OK))
+	assert.Equal(t, checkers.CRITICAL, optimizeStatus(101, checkers.OK))
+	assert.Equal(t, checkers.OK, optimizeStatus(40, checkers.OK))
+	assert.Equal(t, checkers.WARNING, optimizeStatus(39, checkers.OK))
+	assert.Equal(t, checkers.WARNING, optimizeStatus(10, checkers.OK))
+	assert.Equal(t, checkers.CRITICAL, optimizeStatus(9, checkers.OK))
 }

--- a/check-procs/lib/check_procs_test.go
+++ b/check-procs/lib/check_procs_test.go
@@ -71,9 +71,9 @@ func TestOptimizeStatus(t *testing.T) {
 
 func TestGatherMsg(t *testing.T) {
 	var count int64 = 1
-	opts.CmdPat = []string{"foo", "bar"}
+	opts.CmdPatterns = []string{"foo", "bar"}
 
-	for _, pattern := range opts.CmdPat {
+	for _, pattern := range opts.CmdPatterns {
 		expected := fmt.Sprintf("Found %d matching processes; cmd /%s/", count, pattern)
 		assert.Equal(t, expected, gatherMsg(count, pattern))
 	}

--- a/check-procs/lib/check_procs_test.go
+++ b/check-procs/lib/check_procs_test.go
@@ -48,7 +48,7 @@ func TestProcs(t *testing.T) {
 	}
 }
 
-func TestOptimizeStatus(t *testing.T) {
+func TestMergeStatus(t *testing.T) {
 	var CritOver int64 = 100
 	var WarningOver int64 = 80
 	var WarningUnder int64 = 40
@@ -59,14 +59,14 @@ func TestOptimizeStatus(t *testing.T) {
 	opts.WarningUnder = WarningUnder
 	opts.CritUnder = CritUnder
 
-	assert.Equal(t, checkers.OK, optimizeStatus(80, checkers.OK))
-	assert.Equal(t, checkers.WARNING, optimizeStatus(81, checkers.OK))
-	assert.Equal(t, checkers.WARNING, optimizeStatus(100, checkers.OK))
-	assert.Equal(t, checkers.CRITICAL, optimizeStatus(101, checkers.OK))
-	assert.Equal(t, checkers.OK, optimizeStatus(40, checkers.OK))
-	assert.Equal(t, checkers.WARNING, optimizeStatus(39, checkers.OK))
-	assert.Equal(t, checkers.WARNING, optimizeStatus(10, checkers.OK))
-	assert.Equal(t, checkers.CRITICAL, optimizeStatus(9, checkers.OK))
+	assert.Equal(t, checkers.OK, mergeStatus(80, checkers.OK))
+	assert.Equal(t, checkers.WARNING, mergeStatus(81, checkers.OK))
+	assert.Equal(t, checkers.WARNING, mergeStatus(100, checkers.OK))
+	assert.Equal(t, checkers.CRITICAL, mergeStatus(101, checkers.OK))
+	assert.Equal(t, checkers.OK, mergeStatus(40, checkers.OK))
+	assert.Equal(t, checkers.WARNING, mergeStatus(39, checkers.OK))
+	assert.Equal(t, checkers.WARNING, mergeStatus(10, checkers.OK))
+	assert.Equal(t, checkers.CRITICAL, mergeStatus(9, checkers.OK))
 }
 
 func TestGatherMsg(t *testing.T) {


### PR DESCRIPTION
The Current specification of check-procs, makes it difficult to check multiple processes in one definition.

Setting many definitions has the problem of consuming a large amount of resources instantaneously.

This p-r is to make it possible to perform process monitoring in each pattern when multiple `--pattern` options are specified one definition.

```
$ check-procs -p "sshd" -p "bash"
Procs OK:
Found 5 matching processes; cmd /sshd/
Found 2 matching processes; cmd /bash/
```