### PR TITLE
disable unquoting of go-flags

### DIFF
--- a/check-aws-cloudwatch-logs/lib/check-aws-cloudwatch-logs.go
+++ b/check-aws-cloudwatch-logs/lib/check-aws-cloudwatch-logs.go
@@ -23,13 +23,13 @@ import (
 )
 
 type logOpts struct {
-	LogGroupName        string `long:"log-group-name" required:"true" value-name:"LOG-GROUP-NAME" description:"Log group name"`
-	LogStreamNamePrefix string `long:"log-stream-name-prefix" value-name:"LOG-STREAM-NAME-PREFIX" description:"Log stream name prefix"`
+	LogGroupName        string `long:"log-group-name" required:"true" value-name:"LOG-GROUP-NAME" description:"Log group name" unquote:"false"`
+	LogStreamNamePrefix string `long:"log-stream-name-prefix" value-name:"LOG-STREAM-NAME-PREFIX" description:"Log stream name prefix" unquote:"false"`
 
-	Pattern       string `short:"p" long:"pattern" required:"true" value-name:"PATTERN" description:"Pattern to search for. The value is recognized as the pattern syntax of CloudWatch Logs."`
+	Pattern       string `short:"p" long:"pattern" required:"true" value-name:"PATTERN" description:"Pattern to search for. The value is recognized as the pattern syntax of CloudWatch Logs." unquote:"false"`
 	WarningOver   int    `short:"w" long:"warning-over" value-name:"WARNING" description:"Trigger a warning if matched lines is over a number"`
 	CriticalOver  int    `short:"c" long:"critical-over" value-name:"CRITICAL" description:"Trigger a critical if matched lines is over a number"`
-	StateDir      string `short:"s" long:"state-dir" value-name:"DIR" description:"Dir to keep state files under"`
+	StateDir      string `short:"s" long:"state-dir" value-name:"DIR" description:"Dir to keep state files under" unquote:"false"`
 	ReturnContent bool   `short:"r" long:"return" description:"Output matched lines"`
 }
 

--- a/check-aws-cloudwatch-logs/lib/check-aws-cloudwatch-logs_test.go
+++ b/check-aws-cloudwatch-logs/lib/check-aws-cloudwatch-logs_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/jessevdk/go-flags"
 	"github.com/mackerelio/checkers"
 	"github.com/stretchr/testify/assert"
 
@@ -166,5 +167,40 @@ func Test_cloudwatchLogsPlugin_check(t *testing.T) {
 		res := p.check(testCase.Messages)
 		assert.Equal(t, res.Status, testCase.Status)
 		assert.Equal(t, res.Message, testCase.Message)
+	}
+}
+
+func Test_cloudwatchLogsPlugin_options(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want logOpts
+	}{
+		{
+			name: "quoted string",
+			args: []string{
+				"--log-group-name", `"name"`,
+				"--log-stream-name-prefix", `"prefix"`,
+				"-p", `"err:"`,
+				"-s", `"dir"`,
+			},
+			want: logOpts{
+				LogGroupName:        `"name"`,
+				LogStreamNamePrefix: `"prefix"`,
+				Pattern:             `"err:"`,
+				StateDir:            `"dir"`,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var opts logOpts
+			_, err := flags.ParseArgs(&opts, tt.args)
+			if err != nil {
+				t.Fatal("newCloudwatchLogsPlugin:", err)
+			}
+			assert.Equal(t, tt.want, opts)
+		})
 	}
 }


### PR DESCRIPTION
Fixes #327

go-flags package unquote options by default. This behavior was introduced at:
https://github.com/jessevdk/go-flags/pull/96

In the case of #327, `-p "\"err:\""` will be unquoted, then the same as `-p err:`. So I think `err:` expression might be going to violate the [Filter syntax](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/FilterAndPatternSyntax.html).

**Notes**
I fixed only for *check-aws-cloudwatch-logs* plugin. Other plugins is not fixed yet.