### PR TITLE
[check-aws-cloudwatch-logs] Added option to specify AWS API retry count

### DIFF
--- a/check-aws-cloudwatch-logs/README.md
+++ b/check-aws-cloudwatch-logs/README.md
@@ -55,6 +55,7 @@ command = ["check-aws-cloudwatch-logs", "--log-group-name", "/aws/lambda/sample_
   -c, --critical-over=CRITICAL                           Trigger a critical if matched lines is over a number
   -s, --state-dir=DIR                                    Dir to keep state files under
   -r, --return                                           Output matched lines
+  -t, --max-retries=MAX-RETRIES                          Maximum number of retries to call the AWS API
 ```
 
 Note that for `--pattern` argument, you can use the syntax described in [Filter and Pattern Syntax - Amazon CloudWatch Logs](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/FilterAndPatternSyntax.html). This is not a regular expression.

--- a/check-aws-cloudwatch-logs/lib/check-aws-cloudwatch-logs.go
+++ b/check-aws-cloudwatch-logs/lib/check-aws-cloudwatch-logs.go
@@ -31,6 +31,7 @@ type logOpts struct {
 	CriticalOver  int    `short:"c" long:"critical-over" value-name:"CRITICAL" description:"Trigger a critical if matched lines is over a number"`
 	StateDir      string `short:"s" long:"state-dir" value-name:"DIR" description:"Dir to keep state files under" unquote:"false"`
 	ReturnContent bool   `short:"r" long:"return" description:"Output matched lines"`
+	MaxRetries    int    `short:"t" long:"max-retries" value-name:"MAX-RETRIES" description:"Maximum number of retries to call the AWS API"`
 }
 
 // Do the plugin
@@ -85,12 +86,20 @@ func getStateFile(stateDir, logGroupName, logStreamNamePrefix string, args []str
 	)
 }
 
+func createAWSConfig(opts *logOpts) *aws.Config {
+	conf := aws.NewConfig()
+	if opts.MaxRetries > 0 {
+		return conf.WithMaxRetries(opts.MaxRetries)
+	}
+	return conf
+}
+
 func createService(opts *logOpts) (*cloudwatchlogs.CloudWatchLogs, error) {
 	sess, err := session.NewSession()
 	if err != nil {
 		return nil, err
 	}
-	return cloudwatchlogs.New(sess, aws.NewConfig()), nil
+	return cloudwatchlogs.New(sess, createAWSConfig(opts)), nil
 }
 
 type logState struct {

--- a/check-aws-cloudwatch-logs/lib/check-aws-cloudwatch-logs_test.go
+++ b/check-aws-cloudwatch-logs/lib/check-aws-cloudwatch-logs_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"testing"
@@ -201,6 +202,29 @@ func Test_cloudwatchLogsPlugin_options(t *testing.T) {
 				t.Fatal("newCloudwatchLogsPlugin:", err)
 			}
 			assert.Equal(t, tt.want, opts)
+		})
+	}
+}
+
+func Test_createAWSConfig(t *testing.T) {
+	tests := []struct {
+		opts *logOpts
+		want *aws.Config
+	}{
+		{
+			opts: &logOpts{MaxRetries: 0},
+			want: aws.NewConfig(),
+		},
+		{
+			opts: &logOpts{MaxRetries: 1},
+			want: aws.NewConfig().WithMaxRetries(1),
+		},
+	}
+
+	for i, tt := range tests {
+		t.Run(fmt.Sprintf("case:%d", i), func(t *testing.T) {
+			res := createAWSConfig(tt.opts)
+			assert.Equal(t, tt.want, res)
 		})
 	}
 }


### PR DESCRIPTION
When using check-aws-cloudwatch-logs, the following error could occur:
`CloudWatch Logs UNKNOWN: ThrottlingException: Rate exceeded status code: 400, request id: xxxxxxxxxx`
As a result of investigation, it was caused by `Throttling` of` cloudwatchlogs.FilterLogEvents` function used in check-aws-cloudwatch-logs.

In order to avoid this error as much as possible, it is now possible to set the number of retries for aws-sdk-go API call.
