### PR TITLE
[check-ssl-cert] check intermediate- and root-certificates

### DIFF
--- a/check-ssl-cert/lib/check-ssl-cert.go
+++ b/check-ssl-cert/lib/check-ssl-cert.go
@@ -74,5 +74,11 @@ func getCert(addr string) (*x509.Certificate, error) {
 	if len(certs) < 1 {
 		return nil, fmt.Errorf("no certifiations are available")
 	}
-	return certs[0], err
+	cert := certs[0]
+	for _, c := range certs[1:] {
+		if c.NotAfter.Before(cert.NotAfter) {
+			cert = c
+		}
+	}
+	return cert, err
 }


### PR DESCRIPTION
The intermediate- and root-certificates received from the server will be checked.

To check the raw certificates sent from the server:

```console
% openssl s_client -servername <domain> -connect  <domain>:443 -showcerts </dev/null >c.pem
% openssl crl2pkcs7 -nocrl -certfile c.pem | openssl pkcs7 -print_certs -text -noout
```