### PR TITLE
fix check-load percpu output

### DIFF
--- a/check-load/lib/check_load.go
+++ b/check-load/lib/check_load.go
@@ -63,11 +63,13 @@ func run(args []string) *checkers.Checker {
 		return checkers.Unknown(err.Error())
 	}
 
+	var thresholds_per_cpu []float64
 	result := checkers.OK
 	for i, load := range loadavgs {
 		if opts.PerCPU {
 			numCPU := runtime.NumCPU()
 			load = load / float64(numCPU)
+			thresholds_per_cpu = append(thresholds_per_cpu, load)
 		}
 		if load > cload[i] {
 			result = checkers.CRITICAL
@@ -78,6 +80,11 @@ func run(args []string) *checkers.Checker {
 		}
 	}
 
-	msg := fmt.Sprintf("load average: %.2f, %.2f, %.2f", loadavgs[0], loadavgs[1], loadavgs[2])
+	var msg string
+	if opts.PerCPU {
+		msg = fmt.Sprintf("load average: %.2f, %.2f, %.2f", thresholds_per_cpu[0], thresholds_per_cpu[1], thresholds_per_cpu[2])
+	} else {
+		msg = fmt.Sprintf("load average: %.2f, %.2f, %.2f", loadavgs[0], loadavgs[1], loadavgs[2])
+	}
 	return checkers.NewChecker(result, msg)
 }

--- a/check-load/lib/check_load.go
+++ b/check-load/lib/check_load.go
@@ -63,13 +63,13 @@ func run(args []string) *checkers.Checker {
 		return checkers.Unknown(err.Error())
 	}
 
-	var thresholds_per_cpu []float64
+	var thresholdsPerCPU []float64
 	result := checkers.OK
 	for i, load := range loadavgs {
 		if opts.PerCPU {
 			numCPU := runtime.NumCPU()
 			load = load / float64(numCPU)
-			thresholds_per_cpu = append(thresholds_per_cpu, load)
+			thresholdsPerCPU = append(thresholdsPerCPU, load)
 		}
 		if load > cload[i] {
 			result = checkers.CRITICAL
@@ -82,7 +82,7 @@ func run(args []string) *checkers.Checker {
 
 	var msg string
 	if opts.PerCPU {
-		msg = fmt.Sprintf("load average: %.2f, %.2f, %.2f", thresholds_per_cpu[0], thresholds_per_cpu[1], thresholds_per_cpu[2])
+		msg = fmt.Sprintf("load average: %.2f, %.2f, %.2f", thresholdsPerCPU[0], thresholdsPerCPU[1], thresholdsPerCPU[2])
 	} else {
 		msg = fmt.Sprintf("load average: %.2f, %.2f, %.2f", loadavgs[0], loadavgs[1], loadavgs[2])
 	}

--- a/check-load/lib/check_load.go
+++ b/check-load/lib/check_load.go
@@ -63,13 +63,12 @@ func run(args []string) *checkers.Checker {
 		return checkers.Unknown(err.Error())
 	}
 
-	var thresholdsPerCPU []float64
+	var thresholds []float64
 	result := checkers.OK
 	for i, load := range loadavgs {
 		if opts.PerCPU {
 			numCPU := runtime.NumCPU()
 			load = load / float64(numCPU)
-			thresholdsPerCPU = append(thresholdsPerCPU, load)
 		}
 		if load > cload[i] {
 			result = checkers.CRITICAL
@@ -78,13 +77,9 @@ func run(args []string) *checkers.Checker {
 		if load > wload[i] {
 			result = checkers.WARNING
 		}
+		thresholds = append(thresholds, load)
 	}
 
-	var msg string
-	if opts.PerCPU {
-		msg = fmt.Sprintf("load average: %.2f, %.2f, %.2f", thresholdsPerCPU[0], thresholdsPerCPU[1], thresholdsPerCPU[2])
-	} else {
-		msg = fmt.Sprintf("load average: %.2f, %.2f, %.2f", loadavgs[0], loadavgs[1], loadavgs[2])
-	}
+	msg := fmt.Sprintf("load average: %.2f, %.2f, %.2f", thresholds[0], thresholds[1], thresholds[2])
 	return checkers.NewChecker(result, msg)
 }


### PR DESCRIPTION
Hi,

When using check-load `--percpu` option, the cpu load output is not divided per cpu. That could bring some misunderstood when define threshold warning/critical.