### PR TITLE
[check-postgresql] Add sslrootcert option

### DIFF
--- a/check-postgresql/README.md
+++ b/check-postgresql/README.md
@@ -51,15 +51,17 @@ command = ["check-postgresql", "connection", "--host", "127.0.0.1", "--port", "5
 Checks the number of PostgreSQL connections.
 
 ```
-  -H, --host=     Hostname (default: localhost)
-  -p, --port=     Port (default: 5432)
-  -u, --user=     Username (default: postgres)
-  -P, --password= Password [$PGPASSWORD]
-  -d, --database= DBname
-  -s, --sslmode=  SSLmode (default: disable)
-  -t, --timeout=  Maximum wait for connection, in seconds. (default: 5)
-  -w, --warning=  warning if the number of connection is over (default: 70)
-  -c, --critical= critical if the number of connection is over (default: 90)
+  -H, --host=        Hostname (default: localhost)
+  -p, --port=        Port (default: 5432)
+  -u, --user=        Username (default: postgres)
+  -P, --password=    Password [$PGPASSWORD]
+  -d, --database=    DBname
+  -s, --sslmode=     SSLmode (default: disable)
+      --sslrootcert= The root certificate used for SSL certificate verification.
+  -t, --timeout=     Maximum wait for connection, in seconds. (default: 5)
+  -w, --warning=     warning if the number of connection is over (default: 70)
+  -c, --critical=    critical if the number of connection is over (default: 90)
+
 ```
 
 ## For more information

--- a/check-postgresql/lib/check-postgresql.go
+++ b/check-postgresql/lib/check-postgresql.go
@@ -15,13 +15,14 @@ var commands = map[string](func([]string) *checkers.Checker){
 }
 
 type postgresqlSetting struct {
-	Host     string `short:"H" long:"host" default:"localhost" description:"Hostname"`
-	Port     string `short:"p" long:"port" default:"5432" description:"Port"`
-	User     string `short:"u" long:"user" default:"postgres" description:"Username"`
-	Password string `short:"P" long:"password" default:"" description:"Password" env:"PGPASSWORD"`
-	Database string `short:"d" long:"database" description:"DBname"`
-	SSLmode  string `short:"s" long:"sslmode" default:"disable" description:"SSLmode"`
-	Timeout  int    `short:"t" long:"timeout" default:"5" description:"Maximum wait for connection, in seconds."`
+	Host        string `short:"H" long:"host" default:"localhost" description:"Hostname"`
+	Port        string `short:"p" long:"port" default:"5432" description:"Port"`
+	User        string `short:"u" long:"user" default:"postgres" description:"Username"`
+	Password    string `short:"P" long:"password" default:"" description:"Password" env:"PGPASSWORD"`
+	Database    string `short:"d" long:"database" description:"DBname"`
+	SSLmode     string `short:"s" long:"sslmode" default:"disable" description:"SSLmode"`
+	SSLRootCert string `long:"sslrootcert" description:"The root certificate used for SSL certificate verification."`
+	Timeout     int    `short:"t" long:"timeout" default:"5" description:"Maximum wait for connection, in seconds."`
 }
 
 func (p postgresqlSetting) getDriverAndDataSourceName() (string, string) {
@@ -30,6 +31,9 @@ func (p postgresqlSetting) getDriverAndDataSourceName() (string, string) {
 		dbName = p.Database
 	}
 	dataSourceName := fmt.Sprintf("user=%s password=%s host=%s port=%s dbname=%s sslmode=%s connect_timeout=%d", p.User, p.Password, p.Host, p.Port, dbName, p.SSLmode, p.Timeout)
+	if p.SSLRootCert != "" {
+		dataSourceName += fmt.Sprintf(" sslrootcert=%s", p.SSLRootCert)
+	}
 	return "postgres", dataSourceName
 }
 


### PR DESCRIPTION
This PR adds the [`sslrootcert` option](https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNECT-SSLROOTCERT) to `check-postgresql` in order to specify the root certificate for SSL certificate verification. This should be used with `sslverify=verify-ca` or `verify-full`.

I don't give a short name since `sslrootcert` is not the popular use case compared to other options for now. 

## How to use

### 1. Create certificates

cf. https://www.postgresql.org/docs/current/ssl-tcp.html 

```sh
$ mkdir -p certs
$ pushd certs
$ openssl req -new -nodes -text -out root.csr \
  -keyout root.key -subj "/CN=root.example.local"
$ chmod og-rwx root.key
$ openssl x509 -req -in root.csr -text -days 365 -sha256 \
  -extensions v3_ca -signkey root.key \
  -out root.crt
$ openssl req -new -nodes -text -out server.csr \
  -keyout server.key -subj "/CN=postgresql.example.local"
$ chmod og-rwx server.key
$ openssl x509 -req -in server.csr -text -days 365 -sha256 \
  -CA root.crt -CAkey root.key -CAcreateserial \
  -out server.crt
$ popd
```

### 2. Run postgresql with docker

```sh
$ docker run -v `realpath certs`:/var/lib/postgresql/certs \
  -e POSTGRES_PASSWORD=password \
  -p 5432:5432 \
  postgres -c ssl=on \
    -c ssl_cert_file=/var/lib/postgresql/certs/server.crt \
    -c ssl_key_file=/var/lib/postgresql/certs/server.key
```

### 3. Check postgres with `check-postgresql` and the created root certificate

```sh
$ ./build/check-postgresql connection -H 127.0.0.1 -P password # Should success because the default SSLMode is `default`
PostgreSQL Connection OK: 6 connections

$ ./build/check-postgresql connection -H 127.0.0.1 -P password -s verify-ca # Should fail because the root certificate is not exist in the default path (` ~/.postgresql/root.crt`.)
PostgreSQL Connection UNKNOWN: x509: certificate signed by unknown authority

$ ./build/check-postgresql connection -H 127.0.0.1 -P password -s verify-ca --sslrootcert `realpath ./certs/root.crt`
PostgreSQL Connection OK: 6 connections
```
