### PR TITLE
Closes #455 check-load fix null pointer issue when critical

### DIFF
--- a/check-load/lib/check_load.go
+++ b/check-load/lib/check_load.go
@@ -63,23 +63,24 @@ func run(args []string) *checkers.Checker {
 		return checkers.Unknown(err.Error())
 	}
 
-	var thresholds []float64
-	result := checkers.OK
-	for i, load := range loadavgs {
-		if opts.PerCPU {
-			numCPU := runtime.NumCPU()
-			load = load / float64(numCPU)
+	if opts.PerCPU {
+		numCPU := runtime.NumCPU()
+		for i, load := range loadavgs {
+			loadavgs[i] = load / float64(numCPU)
 		}
-		if load > cload[i] {
+	}
+
+	result := checkers.OK
+	for i := range loadavgs {
+		if loadavgs[i] > cload[i] {
 			result = checkers.CRITICAL
 			break
 		}
-		if load > wload[i] {
+		if loadavgs[i] > wload[i] {
 			result = checkers.WARNING
 		}
-		thresholds = append(thresholds, load)
 	}
 
-	msg := fmt.Sprintf("load average: %.2f, %.2f, %.2f", thresholds[0], thresholds[1], thresholds[2])
+	msg := fmt.Sprintf("load average: %.2f, %.2f, %.2f", loadavgs[0], loadavgs[1], loadavgs[2])
 	return checkers.NewChecker(result, msg)
 }


### PR DESCRIPTION
Moving the "if opts.PerCPU" into its own for loop makes the code cleaner in my opinion. There are 2 loops now but is is only a loop of 3.

It is important to go through all the loops to get the load divided by cpu (if that option selected). However, on the flip side it is important to not loop through all of the loops when you have reached a critical threshold.

This has to due to how the critical and warn are like this "-w 1,1,1 -c 2,2,2" and the actual value could be 2, 1.5, 1.  
In this scenario the 1st minute average is critical but if we keep looping 5 and 15 minute average would put it back to a Warning and we don't want that.  

We could have added an additional if critical (previous loop) before moving on to warning but it gets messy. 

I also pulled the runtime.NumCPU() outside of the loop as this should only be called once. 