### PR TITLE
[ci] run tests on the workflow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ all: clean testconvention test build rpm deb
 .PHONY: test
 test: lint
 	go test $(TESTFLAGS) ./...
+	./test.bash
 
 .PHONY: devel-deps
 devel-deps:

--- a/check-disk/test.sh
+++ b/check-disk/test.sh
@@ -1,17 +1,13 @@
 #!/bin/sh
 
-prog=$(basename $0)
-cd $(dirname $0)
+prog=$(basename "$0")
+cd "$(dirname "$0")" || exit
 PATH=$(pwd):$PATH
-plugin=$(basename $(pwd))
-if ! which -s $plugin
+plugin=$(basename "$(pwd)")
+if ! which "$plugin" >/dev/null
 then
 	echo "$prog: $plugin is not installed" >&2
 	exit 2
 fi
 
-if $plugin >/dev/null 2>&1; then
-	echo OK
-else
-	echo FAIL
-fi
+exec $plugin

--- a/check-ldap/test.sh
+++ b/check-ldap/test.sh
@@ -1,32 +1,31 @@
 #!/bin/sh
 
-prog=$(basename $0)
-if ! [[ -S /var/run/docker.sock ]]
+prog=$(basename "$0")
+if ! [ -S /var/run/docker.sock ]
 then
 	echo "$prog: there are no running docker" >&2
 	exit 2
 fi
 
-cd $(dirname $0)
+cd "$(dirname "$0")" || exit
 PATH=$(pwd):$PATH
-plugin=$(basename $(pwd))
-if ! which -s $plugin
+plugin=$(basename "$(pwd)")
+if ! which "$plugin" >/dev/null
 then
 	echo "$prog: $plugin is not installed" >&2
 	exit 2
 fi
 
+port=10389
+image=osixia/openldap
+password=passpass
+
 # By default, LDAP_DOMAIN=example.org and LDAP_ORGANISATION=Example Inc
-docker run --name test-$plugin -p 389:389 -d \
-	-e 'LDAP_ADMIN_PASSWORD=passpass' \
-	osixia/openldap
+docker run --name "test-$plugin" -p "$port:389" -d \
+	-e "LDAP_ADMIN_PASSWORD=$password" \
+	"$image"
 trap 'docker stop test-$plugin; docker rm test-$plugin; exit' EXIT
 sleep 10
 
 base_dn='dc=example,dc=org'
-if $plugin -D "cn=admin,$base_dn" -P passpass -b "$base_dn" -c 2 -w 1
-then
-	echo OK
-else
-	echo FAIL
-fi
+exec $plugin -p $port -D "cn=admin,$base_dn" -P "$password" -b "$base_dn" -c 2 -w 1

--- a/check-postgresql/test.sh
+++ b/check-postgresql/test.sh
@@ -1,16 +1,16 @@
 #!/bin/sh
 
-prog=$(basename $0)
-if ! [[ -S /var/run/docker.sock ]]
+prog=$(basename "$0")
+if ! [ -S /var/run/docker.sock ]
 then
 	echo "$prog: there are no running docker" >&2
 	exit 2
 fi
 
-cd $(dirname $0)
+cd "$(dirname "$0")" || exit
 PATH=$(pwd):$PATH
-plugin=$(basename $(pwd))
-if ! which -s $plugin
+plugin=$(basename "$(pwd)")
+if ! which "$plugin" >/dev/null
 then
 	echo "$prog: $plugin is not installed" >&2
 	exit 2
@@ -18,16 +18,14 @@ fi
 
 user=postgres
 password=passpass
+port=15432
+image=postgres:11
+
 docker run -d \
-	--name test-$plugin \
-	-p 15432:5432 \
-	-e POSTGRES_PASSWORD=$password postgres:11
+	--name "test-$plugin" \
+	-p "$port:5432" \
+	-e "POSTGRES_PASSWORD=$password" "$image"
 trap 'docker stop test-$plugin; docker rm test-$plugin; exit' EXIT
 sleep 10
 
-if $plugin connection --port 15432 --user=$user --password=$password >/dev/null 2>&1
-then
-	echo OK
-else
-	echo FAIL
-fi
+exec $plugin connection --port $port --user=$user --password=$password

--- a/check-redis/test.sh
+++ b/check-redis/test.sh
@@ -1,28 +1,27 @@
 #!/bin/sh
 
-prog=$(basename $0)
-if ! [[ -S /var/run/docker.sock ]]
+prog=$(basename "$0")
+if ! [ -S /var/run/docker.sock ]
 then
 	echo "$prog: there are no running docker" >&2
 	exit 2
 fi
 
-cd $(dirname $0)
+cd "$(dirname "$0")" || exit
 PATH=$(pwd):$PATH
-plugin=$(basename $(pwd))
-if ! which -s $plugin
+plugin=$(basename "$(pwd)")
+if ! which "$plugin" >/dev/null
 then
 	echo "$prog: $plugin is not installed" >&2
 	exit 2
 fi
 
-docker run --name test-$plugin -p 16379:6379 -d redis:5 --requirepass passpass
+password=passpass
+port=16379
+image=redis:5
+
+docker run --name "test-$plugin" -p "$port:6379" -d "$image" --requirepass "$password"
 trap 'docker stop test-$plugin; docker rm test-$plugin; exit' EXIT
 sleep 10
 
-if $plugin reachable --port 16379 --password passpass >/dev/null 2>&1
-then
-	echo OK
-else
-	echo FAIL
-fi
+exec $plugin reachable --port $port --password $password

--- a/test.bash
+++ b/test.bash
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+# prepare tests
+for f in check-*/test.sh
+do
+	dir=$(dirname "$f")
+	name=$(basename "$dir")
+	go build -o "$dir/$name" ./"$dir" || exit
+done
+
+# run tests
+declare -A plugins=()
+declare -a pids=()
+for f in check-*/test.sh
+do
+	./"$f" &
+	pid=$!
+	plugins[$pid]="$f"
+	pids+=("$pid")
+done
+
+# collect the results
+declare -a results=()
+status=0
+for i in "${pids[@]}"
+do
+	if wait "$i"
+	then
+		results+=("OK: ${plugins[$i]}")
+	else
+		results+=("ERR: ${plugins[$i]}")
+		status=1
+	fi
+done
+echo '======' >&2
+for s in "${results[@]}"
+do
+	echo "$s" >&2
+done
+exit $status


### PR DESCRIPTION
I changed workflow to run tests (**&lt;plugin&gt;/test.sh**) for each plugins.

The "make lint cover testconvention test" task ends up with the reports of each tests of the plugin.

```
OK: check-disk/test.sh
OK: check-ldap/test.sh
OK: check-postgresql/test.sh
OK: check-redis/test.sh
```

see also mackerelio/mackerel-agent-plugins#771