### PR TITLE
[check-mysql] add --tls, --tls-root-cert and --tls-skip-verify options

### DIFF
--- a/check-mysql/README.md
+++ b/check-mysql/README.md
@@ -60,7 +60,7 @@ Checks the MySQL server uptime.
   -S, --socket=         Path to unix socket
   -u, --user=           Username (default: root)
   -P, --password=       Password [$MYSQL_PASSWORD]
-      --tls             Enable TLS connection
+      --tls             Enables TLS connection
       --tls-root-cert=  The root certificate used for TLS certificate verification
       --tls-skip-verify Disable TLS certificate verification
   -c, --critical=       critical if the uptime less than (default: 0)

--- a/check-mysql/README.md
+++ b/check-mysql/README.md
@@ -6,7 +6,7 @@ Checks for MySQL.
 
 ## Synopsis
 ```
-check-mysql connection --host=127.0.0.1 --port=3306 --user=USER --password=PASSWORD --tls --tls-root-cert=ca.pem --warning=250 --critical=280
+check-mysql connection --host=127.0.0.1 --port=3306 --user=USER --password=PASSWORD --tls --tls-root-cert=ca.pem --tls-skip-verify --warning=250 --critical=280
 ```
 
 ## Installation
@@ -55,15 +55,16 @@ command = ["check-mysql", "connection", "--host", "127.0.0.1", "--port", "3306",
 Checks the MySQL server uptime.
 
 ```
-  -H, --host=          Hostname (default: localhost)
-  -p, --port=          Port (default: 3306)
-  -S, --socket=        Path to unix socket
-  -u, --user=          Username (default: root)
-  -P, --password=      Password [$MYSQL_PASSWORD]
-      --tls            Enable TLS connection
-      --tls-root-cert= The root certificate used for TLS certificate verification
-  -c, --critical=      critical if the uptime less than (default: 0)
-  -w, --warning=       warning if the uptime less than (default: 0)
+  -H, --host=           Hostname (default: localhost)
+  -p, --port=           Port (default: 3306)
+  -S, --socket=         Path to unix socket
+  -u, --user=           Username (default: root)
+  -P, --password=       Password [$MYSQL_PASSWORD]
+      --tls             Enable TLS connection
+      --tls-root-cert=  The root certificate used for TLS certificate verification
+      --tls-skip-verify Disable TLS certificate verification
+  -c, --critical=       critical if the uptime less than (default: 0)
+  -w, --warning=        warning if the uptime less than (default: 0)
 ```
 
 #### `readonly` subcommand
@@ -71,13 +72,14 @@ Checks the MySQL server uptime.
 Checks the MySQL server is readonly or not.
 
 ```
-  -H, --host=          Hostname (default: localhost)
-  -p, --port=          Port (default: 3306)
-  -S, --socket=        Path to unix socket
-  -u, --user=          Username (default: root)
-  -P, --password=      Password [$MYSQL_PASSWORD]
-      --tls            Enable TLS connection
-      --tls-root-cert= The root certificate used for TLS certificate verification
+  -H, --host=           Hostname (default: localhost)
+  -p, --port=           Port (default: 3306)
+  -S, --socket=         Path to unix socket
+  -u, --user=           Username (default: root)
+  -P, --password=       Password [$MYSQL_PASSWORD]
+      --tls             Enable TLS connection
+      --tls-root-cert=  The root certificate used for TLS certificate verification
+      --tls-skip-verify Disable TLS certificate verification
 ```
 
 #### `replication` subcommand
@@ -85,15 +87,16 @@ Checks the MySQL server is readonly or not.
 Checks MySQL replication status and its second behind master.
 
 ```
-  -H, --host=          Hostname (default: localhost)
-  -p, --port=          Port (default: 3306)
-  -S, --socket=        Path to unix socket
-  -u, --user=          Username (default: root)
-  -P, --password=      Password [$MYSQL_PASSWORD]
-      --tls            Enable TLS connection
-      --tls-root-cert= The root certificate used for TLS certificate verification
-  -c, --critical=      critical if the seconds behind master is over (default: 250)
-  -w, --warning=       warning if the seconds behind master is over (default: 200)
+  -H, --host=           Hostname (default: localhost)
+  -p, --port=           Port (default: 3306)
+  -S, --socket=         Path to unix socket
+  -u, --user=           Username (default: root)
+  -P, --password=       Password [$MYSQL_PASSWORD]
+      --tls             Enable TLS connection
+      --tls-root-cert=  The root certificate used for TLS certificate verification
+      --tls-skip-verify Disable TLS certificate verification
+  -c, --critical=       critical if the seconds behind master is over (default: 250)
+  -w, --warning=        warning if the seconds behind master is over (default: 200)
 ```
 
 #### `connection` subcommand
@@ -101,15 +104,16 @@ Checks MySQL replication status and its second behind master.
 Checks the number of MySQL connections.
 
 ```
-  -H, --host=          Hostname (default: localhost)
-  -p, --port=          Port (default: 3306)
-  -S, --socket=        Path to unix socket
-  -u, --user=          Username (default: root)
-  -P, --password=      Password [$MYSQL_PASSWORD]
-      --tls            Enable TLS connection
-      --tls-root-cert= The root certificate used for TLS certificate verification
-  -c, --critical=      critical if the number of connection is over (default: 250)
-  -w, --warning=       warning if the number of connection is over (default: 200)
+  -H, --host=           Hostname (default: localhost)
+  -p, --port=           Port (default: 3306)
+  -S, --socket=         Path to unix socket
+  -u, --user=           Username (default: root)
+  -P, --password=       Password [$MYSQL_PASSWORD]
+      --tls             Enable TLS connection
+      --tls-root-cert=  The root certificate used for TLS certificate verification
+      --tls-skip-verify Disable TLS certificate verification
+  -c, --critical=       critical if the number of connection is over (default: 250)
+  -w, --warning=        warning if the number of connection is over (default: 200)
 ```
 
 ### For more information

--- a/check-mysql/README.md
+++ b/check-mysql/README.md
@@ -6,7 +6,7 @@ Checks for MySQL.
 
 ## Synopsis
 ```
-check-mysql connection --host=127.0.0.1 --port=3306 --user=USER --password=PASSWORD --warning=250 --critical=280
+check-mysql connection --host=127.0.0.1 --port=3306 --user=USER --password=PASSWORD --tls --warning=250 --critical=280
 ```
 
 ## Installation
@@ -60,6 +60,7 @@ Checks the MySQL server uptime.
   -S, --socket=   Path to unix socket
   -u, --user=     Username (default: root)
   -P, --password= Password [$MYSQL_PASSWORD]
+      --tls       Enable TLS connection
   -c, --critical= critical if the uptime less than (default: 0)
   -w, --warning=  warning if the uptime less than (default: 0)
 ```
@@ -74,6 +75,7 @@ Checks the MySQL server is readonly or not.
   -S, --socket=   Path to unix socket
   -u, --user=     Username (default: root)
   -P, --password= Password [$MYSQL_PASSWORD]
+      --tls       Enable TLS connection
 ```
 
 #### `replication` subcommand
@@ -86,6 +88,7 @@ Checks MySQL replication status and its second behind master.
   -S, --socket=   Path to unix socket
   -u, --user=     Username (default: root)
   -P, --password= Password [$MYSQL_PASSWORD]
+      --tls       Enable TLS connection
   -c, --critical= critical if the seconds behind master is over (default: 250)
   -w, --warning=  warning if the seconds behind master is over (default: 200)
 ```
@@ -100,6 +103,7 @@ Checks the number of MySQL connections.
   -S, --socket=   Path to unix socket
   -u, --user=     Username (default: root)
   -P, --password= Password [$MYSQL_PASSWORD]
+      --tls       Enable TLS connection
   -c, --critical= critical if the number of connection is over (default: 250)
   -w, --warning=  warning if the number of connection is over (default: 200)
 ```

--- a/check-mysql/README.md
+++ b/check-mysql/README.md
@@ -6,7 +6,7 @@ Checks for MySQL.
 
 ## Synopsis
 ```
-check-mysql connection --host=127.0.0.1 --port=3306 --user=USER --password=PASSWORD --tls --warning=250 --critical=280
+check-mysql connection --host=127.0.0.1 --port=3306 --user=USER --password=PASSWORD --tls --tls-root-cert=ca.pem --warning=250 --critical=280
 ```
 
 ## Installation
@@ -55,14 +55,15 @@ command = ["check-mysql", "connection", "--host", "127.0.0.1", "--port", "3306",
 Checks the MySQL server uptime.
 
 ```
-  -H, --host=     Hostname (default: localhost)
-  -p, --port=     Port (default: 3306)
-  -S, --socket=   Path to unix socket
-  -u, --user=     Username (default: root)
-  -P, --password= Password [$MYSQL_PASSWORD]
-      --tls       Enable TLS connection
-  -c, --critical= critical if the uptime less than (default: 0)
-  -w, --warning=  warning if the uptime less than (default: 0)
+  -H, --host=          Hostname (default: localhost)
+  -p, --port=          Port (default: 3306)
+  -S, --socket=        Path to unix socket
+  -u, --user=          Username (default: root)
+  -P, --password=      Password [$MYSQL_PASSWORD]
+      --tls            Enable TLS connection
+      --tls-root-cert= The root certificate used for TLS certificate verification
+  -c, --critical=      critical if the uptime less than (default: 0)
+  -w, --warning=       warning if the uptime less than (default: 0)
 ```
 
 #### `readonly` subcommand
@@ -70,12 +71,13 @@ Checks the MySQL server uptime.
 Checks the MySQL server is readonly or not.
 
 ```
-  -H, --host=     Hostname (default: localhost)
-  -p, --port=     Port (default: 3306)
-  -S, --socket=   Path to unix socket
-  -u, --user=     Username (default: root)
-  -P, --password= Password [$MYSQL_PASSWORD]
-      --tls       Enable TLS connection
+  -H, --host=          Hostname (default: localhost)
+  -p, --port=          Port (default: 3306)
+  -S, --socket=        Path to unix socket
+  -u, --user=          Username (default: root)
+  -P, --password=      Password [$MYSQL_PASSWORD]
+      --tls            Enable TLS connection
+      --tls-root-cert= The root certificate used for TLS certificate verification
 ```
 
 #### `replication` subcommand
@@ -83,14 +85,15 @@ Checks the MySQL server is readonly or not.
 Checks MySQL replication status and its second behind master.
 
 ```
-  -H, --host=     Hostname (default: localhost)
-  -p, --port=     Port (default: 3306)
-  -S, --socket=   Path to unix socket
-  -u, --user=     Username (default: root)
-  -P, --password= Password [$MYSQL_PASSWORD]
-      --tls       Enable TLS connection
-  -c, --critical= critical if the seconds behind master is over (default: 250)
-  -w, --warning=  warning if the seconds behind master is over (default: 200)
+  -H, --host=          Hostname (default: localhost)
+  -p, --port=          Port (default: 3306)
+  -S, --socket=        Path to unix socket
+  -u, --user=          Username (default: root)
+  -P, --password=      Password [$MYSQL_PASSWORD]
+      --tls            Enable TLS connection
+      --tls-root-cert= The root certificate used for TLS certificate verification
+  -c, --critical=      critical if the seconds behind master is over (default: 250)
+  -w, --warning=       warning if the seconds behind master is over (default: 200)
 ```
 
 #### `connection` subcommand
@@ -98,14 +101,15 @@ Checks MySQL replication status and its second behind master.
 Checks the number of MySQL connections.
 
 ```
-  -H, --host=     Hostname (default: localhost)
-  -p, --port=     Port (default: 3306)
-  -S, --socket=   Path to unix socket
-  -u, --user=     Username (default: root)
-  -P, --password= Password [$MYSQL_PASSWORD]
-      --tls       Enable TLS connection
-  -c, --critical= critical if the number of connection is over (default: 250)
-  -w, --warning=  warning if the number of connection is over (default: 200)
+  -H, --host=          Hostname (default: localhost)
+  -p, --port=          Port (default: 3306)
+  -S, --socket=        Path to unix socket
+  -u, --user=          Username (default: root)
+  -P, --password=      Password [$MYSQL_PASSWORD]
+      --tls            Enable TLS connection
+      --tls-root-cert= The root certificate used for TLS certificate verification
+  -c, --critical=      critical if the number of connection is over (default: 250)
+  -w, --warning=       warning if the number of connection is over (default: 200)
 ```
 
 ### For more information

--- a/check-mysql/lib/check-mysql.go
+++ b/check-mysql/lib/check-mysql.go
@@ -16,6 +16,8 @@ type mysqlSetting struct {
 	Socket string `short:"S" long:"socket" default:"" description:"Path to unix socket"`
 	User   string `short:"u" long:"user" default:"root" description:"Username"`
 	Pass   string `short:"P" long:"password" default:"" description:"Password" env:"MYSQL_PASSWORD"`
+
+	EnableTLS bool `long:"tls" description:"Enables TLS connection"`
 }
 
 type mysqlVersion struct {
@@ -70,6 +72,9 @@ func newDB(m mysqlSetting) (*sql.DB, error) {
 		Net:                  proto,
 		Addr:                 target,
 		AllowNativePasswords: true,
+	}
+	if m.EnableTLS {
+		cfg.TLSConfig = "true"
 	}
 
 	return sql.Open("mysql", cfg.FormatDSN())

--- a/check-mysql/lib/check-mysql.go
+++ b/check-mysql/lib/check-mysql.go
@@ -19,8 +19,9 @@ type mysqlSetting struct {
 	User   string `short:"u" long:"user" default:"root" description:"Username"`
 	Pass   string `short:"P" long:"password" default:"" description:"Password" env:"MYSQL_PASSWORD"`
 
-	EnableTLS   bool   `long:"tls" description:"Enables TLS connection"`
-	TLSRootCert string `long:"tls-root-cert" default:"" description:"The root certificate used for TLS certificate verification"`
+	EnableTLS     bool   `long:"tls" description:"Enables TLS connection"`
+	TLSRootCert   string `long:"tls-root-cert" default:"" description:"The root certificate used for TLS certificate verification"`
+	TLSSkipVerify bool   `long:"tls-skip-verify" description:"Disable TLS certificate verification"`
 }
 
 type mysqlVersion struct {
@@ -87,6 +88,7 @@ func newDB(m mysqlSetting) (*sql.DB, error) {
 			certPool.AppendCertsFromPEM(pem)
 			c.RootCAs = certPool
 		}
+		c.InsecureSkipVerify = m.TLSSkipVerify
 		mysql.RegisterTLSConfig("custom", &c)
 		cfg.TLSConfig = "custom"
 	}

--- a/check-mysql/test-tls.sh
+++ b/check-mysql/test-tls.sh
@@ -42,7 +42,7 @@ sleep 1
 docker cp "test-$plugin:/var/lib/mysql/ca.pem" "$cacert"
 
 $plugin connection --port $port --password=$password \
-	--tls --tls-root-cert="$cacert"
+	--tls --tls-root-cert="$cacert" --tls-skip-verify
 status=$?
 docker stop "test-$plugin"
 docker rm "test-$plugin"

--- a/check-mysql/test-tls.sh
+++ b/check-mysql/test-tls.sh
@@ -1,0 +1,45 @@
+#!/bin/sh
+
+prog=$(basename "$0")
+if ! [ -S /var/run/docker.sock ]
+then
+	echo "$prog: there are no running docker" >&2
+	exit 2
+fi
+
+cd "$(dirname "$0")" || exit
+PATH=$(pwd):$PATH
+plugin=$(basename "$(pwd)")
+if ! which "$plugin" >/dev/null
+then
+	echo "$prog: $plugin is not installed" >&2
+	exit 2
+fi
+
+password=passpass
+port=13306
+image=mysql:8
+
+docker run -d \
+	--name "test-$plugin" \
+	-p "$port:3306" \
+	-e "MYSQL_ROOT_PASSWORD=$password" "$image"
+trap 'docker stop test-$plugin; docker rm test-$plugin; exit 1' 1 2 3 15
+
+# wait until bootstrap mysqld..
+for i in $(seq 10)
+do
+	echo "Connecting $i..."
+	if $plugin connection --port $port --password $password >/dev/null 2>&1
+	then
+		break
+	fi
+	sleep 3
+done
+sleep 1
+
+$plugin connection --port $port --password=$password
+status=$?
+docker stop "test-$plugin"
+docker rm "test-$plugin"
+exit $status

--- a/test.bash
+++ b/test.bash
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # prepare tests
-for f in check-*/test.sh
+for f in check-*/test.sh check-*/test-*.sh
 do
 	dir=$(dirname "$f")
 	name=$(basename "$dir")
@@ -11,7 +11,7 @@ done
 # run tests
 declare -A plugins=()
 declare -a pids=()
-for f in check-*/test.sh
+for f in check-*/test.sh check-*/test-*.sh
 do
 	./"$f" &
 	pid=$!


### PR DESCRIPTION
I added three options for use encrypted connection to the server.

* `--tls` Enables TLS connection
* `--tls-root-cert [ca.pem]` The root certificate used for TLS certificate verification
* `--tls-skip-verify` Disable TLS certificate verification