### PR TITLE
check-mysql: Closes `checkReplication` rows

### DIFF
--- a/check-mysql/lib/replication.go
+++ b/check-mysql/lib/replication.go
@@ -95,6 +95,7 @@ func checkReplication(args []string) *checkers.Checker {
 	if err != nil {
 		return checkers.Unknown(fmt.Sprintf("Couldn't execute query: %s", err))
 	}
+	defer rows.Close()
 
 	if !rows.Next() {
 		return checkers.Ok("MySQL is not a replica")


### PR DESCRIPTION
http://jmoiron.github.io/sqlx/#query

> The connection used by the Query remains active until either all rows are exhausted by the iteration via `Next`, or `rows.Close()` is called, at which point it is released. For more information, see the section on the connection pool.
