### PR TITLE
[check-log] add search-in-directory option

### DIFF
--- a/check-log/README.md
+++ b/check-log/README.md
@@ -51,7 +51,7 @@ command = ["check-log", "--file", "/path/to/file", "--pattern", "REGEXP", "--war
       --warning-level=N                          Warning level if pattern has a group
       --critical-level=N                         Critical level if pattern has a group
   -r, --return                                   Return matched line
-      --directory=DIR                            Specify the directory of files to be detected
+      --search-directory=DIR                     Specify the directory of files to be detected
   -F, --file-pattern=FILE                        Check a pattern of files, instead of one file
   -i, --icase                                    Run a case insensitive match
   -s, --state-dir=DIR                            Dir to keep state files under

--- a/check-log/README.md
+++ b/check-log/README.md
@@ -45,12 +45,13 @@ command = ["check-log", "--file", "/path/to/file", "--pattern", "REGEXP", "--war
   -f, --file=FILE                                Path to log file
   -p, --pattern=PAT                              Pattern to search for. If specified multiple, they will be treated together with the AND operator
       --suppress-pattern                         Suppress pattern display
-  -E, --exclude=PAT                              Pattern to exclude from matching
+  -E, --exclude=PAT                              Pattern to exclude from matching. If specified multiple, they will be treated together with the AND operator
   -w, --warning-over=                            Trigger a warning if matched lines is over a number
   -c, --critical-over=                           Trigger a critical if matched lines is over a number
       --warning-level=N                          Warning level if pattern has a group
       --critical-level=N                         Critical level if pattern has a group
   -r, --return                                   Return matched line
+      --directory=DIR                            Specify the directory of files to be detected
   -F, --file-pattern=FILE                        Check a pattern of files, instead of one file
   -i, --icase                                    Run a case insensitive match
   -s, --state-dir=DIR                            Dir to keep state files under

--- a/check-log/README.md
+++ b/check-log/README.md
@@ -51,7 +51,7 @@ command = ["check-log", "--file", "/path/to/file", "--pattern", "REGEXP", "--war
       --warning-level=N                          Warning level if pattern has a group
       --critical-level=N                         Critical level if pattern has a group
   -r, --return                                   Return matched line
-      --search-directory=DIR                     Specify the directory of files to be detected
+      --search-in-directory=DIR                  Specify the directory of files to be detected
   -F, --file-pattern=FILE                        Check a pattern of files, instead of one file
   -i, --icase                                    Run a case insensitive match
   -s, --state-dir=DIR                            Dir to keep state files under

--- a/check-log/lib/check-log.go
+++ b/check-log/lib/check-log.go
@@ -39,7 +39,7 @@ type logOpts struct {
 	WarnLevel           float64  `long:"warning-level" value-name:"N" description:"Warning level if pattern has a group"`
 	CritLevel           float64  `long:"critical-level" value-name:"N" description:"Critical level if pattern has a group"`
 	ReturnContent       bool     `short:"r" long:"return" description:"Return matched line"`
-	Directory           string   `long:"search-directory" value-name:"DIR" description:"Specify the directory of files to be detected"`
+	Directory           string   `long:"search-in-directory" value-name:"DIR" description:"Specify the directory of files to be detected"`
 	FilePattern         string   `short:"F" long:"file-pattern" value-name:"FILE" description:"Check a pattern of files, instead of one file"`
 	CaseInsensitive     bool     `short:"i" long:"icase" description:"Run a case insensitive match"`
 	StateDir            string   `short:"s" long:"state-dir" value-name:"DIR" description:"Dir to keep state files under"`
@@ -63,7 +63,7 @@ func (opts *logOpts) prepare() error {
 	}
 
 	if opts.Directory != "" && opts.FilePattern == "" {
-		return fmt.Errorf("search-directory option must be used with file-pattern option")
+		return fmt.Errorf("search-in-directory option must be used with file-pattern option")
 	}
 
 	var err error

--- a/check-log/lib/check-log.go
+++ b/check-log/lib/check-log.go
@@ -62,6 +62,10 @@ func (opts *logOpts) prepare() error {
 		return fmt.Errorf("No log file specified")
 	}
 
+	if opts.Directory != "" && opts.FilePattern == "" {
+		return fmt.Errorf("directory option must be used with file-pattern option")
+	}
+
 	var err error
 	var reg *regexp.Regexp
 	for _, ptn := range opts.Pattern {

--- a/check-log/lib/check-log.go
+++ b/check-log/lib/check-log.go
@@ -39,7 +39,7 @@ type logOpts struct {
 	WarnLevel           float64  `long:"warning-level" value-name:"N" description:"Warning level if pattern has a group"`
 	CritLevel           float64  `long:"critical-level" value-name:"N" description:"Critical level if pattern has a group"`
 	ReturnContent       bool     `short:"r" long:"return" description:"Return matched line"`
-	Directory           string   `long:"directory" value-name:"DIR" description:"Specify the directory of files to be detected"`
+	Directory           string   `long:"search-directory" value-name:"DIR" description:"Specify the directory of files to be detected"`
 	FilePattern         string   `short:"F" long:"file-pattern" value-name:"FILE" description:"Check a pattern of files, instead of one file"`
 	CaseInsensitive     bool     `short:"i" long:"icase" description:"Run a case insensitive match"`
 	StateDir            string   `short:"s" long:"state-dir" value-name:"DIR" description:"Dir to keep state files under"`
@@ -63,7 +63,7 @@ func (opts *logOpts) prepare() error {
 	}
 
 	if opts.Directory != "" && opts.FilePattern == "" {
-		return fmt.Errorf("directory option must be used with file-pattern option")
+		return fmt.Errorf("search-directory option must be used with file-pattern option")
 	}
 
 	var err error

--- a/check-log/lib/check-log.go
+++ b/check-log/lib/check-log.go
@@ -39,6 +39,7 @@ type logOpts struct {
 	WarnLevel           float64  `long:"warning-level" value-name:"N" description:"Warning level if pattern has a group"`
 	CritLevel           float64  `long:"critical-level" value-name:"N" description:"Critical level if pattern has a group"`
 	ReturnContent       bool     `short:"r" long:"return" description:"Return matched line"`
+	Directory           string   `long:"directory" value-name:"DIR" description:"Specify the directory of files to be detected"`
 	FilePattern         string   `short:"F" long:"file-pattern" value-name:"FILE" description:"Check a pattern of files, instead of one file"`
 	CaseInsensitive     bool     `short:"i" long:"icase" description:"Run a case insensitive match"`
 	StateDir            string   `short:"s" long:"state-dir" value-name:"DIR" description:"Dir to keep state files under"`
@@ -90,8 +91,15 @@ func (opts *logOpts) prepare() error {
 	}
 
 	if opts.FilePattern != "" {
-		dirStr := filepath.Dir(opts.FilePattern)
-		filePat := filepath.Base(opts.FilePattern)
+		var dirStr string
+		var filePat string
+		if opts.Directory != "" {
+			dirStr = opts.Directory
+			filePat = opts.FilePattern
+		} else {
+			dirStr = filepath.Dir(opts.FilePattern)
+			filePat = filepath.Base(opts.FilePattern)
+		}
 		reg, err := regCompileWithCase(filePat, opts.CaseInsensitive)
 		if err != nil {
 			return fmt.Errorf("file-pattern is invalid")

--- a/check-log/lib/check-log.go
+++ b/check-log/lib/check-log.go
@@ -415,13 +415,15 @@ func (opts *logOpts) match(line string) (bool, []string) {
 	return true, matches
 }
 
-func parseFilePattern(directory string, filePattern string, caseInsensitive bool) ([]string, error) {
+func parseFilePattern(directory, filePattern string, caseInsensitive bool) ([]string, error) {
 	var dirStr string
 	var filePat string
 	if directory != "" {
 		dirStr = directory
 		filePat = filePattern
 	} else {
+		// for backward compatibility.
+		// Directory delimiters and regular expressions can conflict in windows environment.
 		dirStr = filepath.Dir(filePattern)
 		filePat = filepath.Base(filePattern)
 	}

--- a/check-log/lib/check-log_test.go
+++ b/check-log/lib/check-log_test.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"runtime"
+	"sort"
 	"strings"
 	"testing"
 	"time"
@@ -964,5 +965,74 @@ func TestRunMultipleExcludePattern(t *testing.T) {
 
 		msg := fmt.Sprintf("%d warnings, %d criticals for pattern /ERROR/ and /TESTAPP/.", test.matchedCount, test.matchedCount)
 		assert.Equal(t, msg, ckr.Message, fmt.Sprintf("chk.Message should be '%s' (actual: '%s')", msg, ckr.Message))
+	}
+}
+
+func TestParseFilePattern(t *testing.T) {
+	dir, err := ioutil.TempDir("", "check-log-test")
+	if err != nil {
+		t.Errorf("something went wrong")
+	}
+	t.Cleanup(func() {
+		os.RemoveAll(dir)
+	})
+
+	logf1 := filepath.Join(dir, "dummy1.txt")
+	fh1, _ := os.Create(logf1)
+	fh1.Close()
+
+	logf2 := filepath.Join(dir, "dummy2.txt")
+	fh2, _ := os.Create(logf2)
+	fh2.Close()
+
+	logf3 := filepath.Join(dir, "DUMMY3.txt")
+	fh3, _ := os.Create(logf3)
+	fh3.Close()
+
+	tests := []struct {
+		desc        string
+		directory   string
+		filePattern string
+		insensitive bool
+		actual      []string
+		skipWindows bool
+	}{
+		{
+			desc:        "filePattern only",
+			directory:   "",
+			filePattern: dir + string(filepath.Separator) + `dummy\d.txt`,
+			insensitive: true,
+			actual:      []string{logf1, logf2, logf3},
+			skipWindows: true,
+		},
+		{
+			desc:        "separate directory, file pattern",
+			directory:   dir,
+			filePattern: `dummy\d.txt`,
+			insensitive: true,
+			actual:      []string{logf1, logf2, logf3},
+			skipWindows: false,
+		},
+		{
+			desc:        "case sensitive",
+			directory:   dir,
+			filePattern: `DUMMY\d.txt`,
+			insensitive: false,
+			actual:      []string{logf3},
+			skipWindows: false,
+		},
+	}
+
+	for _, tt := range tests {
+		if tt.skipWindows && runtime.GOOS == "windows" {
+			continue
+		}
+		list, err := parseFilePattern(tt.directory, tt.filePattern, tt.insensitive)
+		if err != nil {
+			t.Fatalf("failed: %s", err)
+		}
+		sort.Strings(list)
+		sort.Strings(tt.actual)
+		assert.Equal(t, list, tt.actual, fmt.Sprintf("%s - list should be '%s' (actual: '%s')", tt.desc, list, tt.actual))
 	}
 }

--- a/check-log/lib/check-log_test.go
+++ b/check-log/lib/check-log_test.go
@@ -969,13 +969,7 @@ func TestRunMultipleExcludePattern(t *testing.T) {
 }
 
 func TestParseFilePattern(t *testing.T) {
-	dir, err := ioutil.TempDir("", "check-log-test")
-	if err != nil {
-		t.Errorf("something went wrong")
-	}
-	t.Cleanup(func() {
-		os.RemoveAll(dir)
-	})
+	dir := t.TempDir()
 
 	logf1 := filepath.Join(dir, "dummy1.txt")
 	fh1, _ := os.Create(logf1)

--- a/check-log/lib/check-log_test.go
+++ b/check-log/lib/check-log_test.go
@@ -1003,6 +1003,8 @@ func TestParseFilePattern(t *testing.T) {
 			filePattern: dir + string(filepath.Separator) + `dummy\d.txt`,
 			insensitive: true,
 			actual:      []string{logf1, logf2, logf3},
+			// If in Windows, '\\' is used as both path separator and special meaning of regular expression.
+			// Thus the result of filepath.Dir do not become a expected directory name.
 			skipWindows: true,
 		},
 		{


### PR DESCRIPTION
Directory delimiters and regular expressions can conflict in windows.
Therefore, add a directory option to facilitate file-pattern settings.