### PR TITLE
upgrade Go: 1.16 -> 1.17

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,13 +9,12 @@ on:
     - v*
   pull_request:
 env:
-  GO111MODULE: on
   DEBIAN_FRONTEND: noninteractive
 jobs:
   test:
     strategy:
       matrix:
-        go: ["1.16.x"]
+        go: ["1.17.x", "1.16.x"]
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:
@@ -35,7 +34,7 @@ jobs:
   test-windows:
     strategy:
       matrix:
-        go: ["1.16.x"]
+        go: ["1.17.x", "1.16.x"]
     runs-on: windows-latest
     steps:
       - uses: actions/setup-go@v2
@@ -70,7 +69,7 @@ jobs:
             ${{ runner.os }}-go-
       - uses: actions/setup-go@v2
         with:
-          go-version: 1.16.x
+          go-version: 1.17.x
       - uses: actions/checkout@v2
       - run: make clean build rpm deb
       - uses: actions/upload-artifact@v2


### PR DESCRIPTION
I did upgrade Go toolchain.

Next Go version will be scheduled Mar 2022.
https://go.dev/blog/go1.18beta2