### PR TITLE
[check-aws-cloudwatch-logs] use FilterLogEventsPages API

### DIFF
--- a/check-aws-cloudwatch-logs/lib/check-aws-cloudwatch-logs.go
+++ b/check-aws-cloudwatch-logs/lib/check-aws-cloudwatch-logs.go
@@ -114,6 +114,7 @@ func (p *awsCloudwatchLogsPlugin) collect(now time.Time) ([]string, error) {
 	}
 	if s.StartTime == nil || *s.StartTime <= now.Add(-time.Hour).Unix()*1000 {
 		s.StartTime = aws.Int64(now.Add(-1*time.Minute).Unix() * 1000)
+		s.NextToken = nil
 	}
 	var messages []string
 	input := &cloudwatchlogs.FilterLogEventsInput{

--- a/check-aws-cloudwatch-logs/lib/check-aws-cloudwatch-logs.go
+++ b/check-aws-cloudwatch-logs/lib/check-aws-cloudwatch-logs.go
@@ -136,13 +136,13 @@ func (p *awsCloudwatchLogsPlugin) collect(now time.Time) ([]string, error) {
 		if lastPage {
 			s.NextToken = nil
 		}
+		err = p.saveState(s)
+		if err != nil {
+			return false
+		}
 		time.Sleep(150 * time.Millisecond)
 		return true
 	})
-	if err != nil {
-		return nil, err
-	}
-	err = p.saveState(s)
 	if err != nil {
 		return nil, err
 	}

--- a/check-aws-cloudwatch-logs/lib/check-aws-cloudwatch-logs.go
+++ b/check-aws-cloudwatch-logs/lib/check-aws-cloudwatch-logs.go
@@ -133,6 +133,9 @@ func (p *awsCloudwatchLogsPlugin) collect(now time.Time) ([]string, error) {
 			}
 		}
 		s.NextToken = output.NextToken
+		if lastPage {
+			s.NextToken = nil
+		}
 		time.Sleep(150 * time.Millisecond)
 		return true
 	})

--- a/check-aws-cloudwatch-logs/lib/check-aws-cloudwatch-logs_test.go
+++ b/check-aws-cloudwatch-logs/lib/check-aws-cloudwatch-logs_test.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/jessevdk/go-flags"
 	"github.com/mackerelio/checkers"
@@ -95,13 +96,13 @@ func Test_cloudwatchLogsPlugin_collect(t *testing.T) {
 			LogGroupName: "test-group",
 		},
 	}
-	messages, err := p.collect()
+	messages, err := p.collect(time.Unix(0, 0))
 	assert.Equal(t, err, nil, "err should be nil")
 	assert.Equal(t, len(messages), 6)
 	cnt, _ := ioutil.ReadFile(file.Name())
 	var s logState
 	json.NewDecoder(bytes.NewReader(cnt)).Decode(&s)
-	assert.Equal(t, *s.NextToken, "2")
+	assert.Equal(t, s, logState{StartTime: aws.Int64(5 + 1)})
 }
 
 func Test_cloudwatchLogsPlugin_check(t *testing.T) {


### PR DESCRIPTION
Now check-aws-cloudwatch-logs plugin uses `FilterLogEvents` API and implements pagination by itself. But I think it's better to use `FilterLogEventsPages` API.