### PR TITLE
[check-aws-cloudwatch-logs] stop gracefully on timeout signal

### DIFF
--- a/check-aws-cloudwatch-logs/lib/check-aws-cloudwatch-logs.go
+++ b/check-aws-cloudwatch-logs/lib/check-aws-cloudwatch-logs.go
@@ -6,7 +6,6 @@ import (
 	"crypto/md5"
 	"encoding/json"
 	"fmt"
-	"log"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -42,15 +41,8 @@ type logOpts struct {
 
 // Do the plugin
 func Do() {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	sigCh := make(chan os.Signal, 1)
-	go func() {
-		sig := <-sigCh
-		log.Printf("check-aws-cloudwatch-logs is exiting: caught a signal: %v", sig)
-		cancel()
-	}()
-	signal.Notify(sigCh, defaultSignal)
+	ctx, stop := signal.NotifyContext(context.Background(), defaultSignal)
+	defer stop()
 
 	ckr := run(ctx, os.Args[1:])
 	ckr.Name = "CloudWatch Logs"

--- a/check-aws-cloudwatch-logs/lib/check-aws-cloudwatch-logs_unix.go
+++ b/check-aws-cloudwatch-logs/lib/check-aws-cloudwatch-logs_unix.go
@@ -1,0 +1,9 @@
+package checkawscloudwatchlogs
+
+import (
+	"syscall"
+)
+
+func init() {
+	defaultSignal = syscall.SIGTERM
+}


### PR DESCRIPTION
similar to #268

I fixed to handle timeout signal from mackerel-agent in `check-aws-cloudwatch-logs` plugin to stop the plugin gracefully.

Now, when received timeout signal, `check-aws-cloudwatch-logs` skip checking log events fetched until then and these log events will never be checked.
So, I fixed the plugin to check log events before stopping when received timeout signal.