### PR TITLE
check-tcp: add no-restime-success-msg option

### DIFF
--- a/check-tcp/README.md
+++ b/check-tcp/README.md
@@ -42,22 +42,23 @@ command = ["check-tcp", "-H", "localhost", "-p", "4224", "-w", "3", "-c", "5"]
 ### Options
 
 ```
-      --service=              Service name. e.g. ftp, smtp, pop, imap and so on
-  -H, --hostname=             Host name or IP Address
-  -p, --port=                 Port number
-  -s, --send=                 String to send to the server
-  -e, --expect-pattern=       Regexp pattern to expect in server response
-  -q, --quit=                 String to send server to initiate a clean close of the connection
-  -S, --ssl                   Use SSL for the connection.
-  -U, --unix-sock=            Unix Domain Socket
-      --no-check-certificate  Do not check certificate
-  -t, --timeout=              Seconds before connection times out (default: 10)
-  -m, --maxbytes=             Close connection once more than this number of bytes are received
-  -d, --delay=                Seconds to wait between sending string and polling for response
-  -w, --warning=              Response time to result in warning status (seconds)
-  -c, --critical=             Response time to result in critical status (seconds)
-  -E, --escape                Can use \n, \r, \t or \ in send or quit string. Must come before send or quit option. By default, nothing added to send, \r\n added to end of quit
-  -W, --error-warning         Set the error level to warning when exiting with unexpected error (default: critical). In the case of request succeeded, evaluation result of -c option eval takes priority.
+      --service=                Service name. e.g. ftp, smtp, pop, imap and so on
+  -H, --hostname=               Host name or IP Address
+  -p, --port=                   Port number
+  -s, --send=                   String to send to the server
+  -e, --expect-pattern=         Regexp pattern to expect in server response
+  -q, --quit=                   String to send server to initiate a clean close of the connection
+  -S, --ssl                     Use SSL for the connection.
+  -U, --unix-sock=              Unix Domain Socket
+      --no-check-certificate    Do not check certificate
+  -t, --timeout=                Seconds before connection times out (default: 10)
+  -m, --maxbytes=               Close connection once more than this number of bytes are received
+  -d, --delay=                  Seconds to wait between sending string and polling for response
+  -w, --warning=                Response time to result in warning status (seconds)
+  -c, --critical=               Response time to result in critical status (seconds)
+  -E, --escape                  Can use \n, \r, \t or \ in send or quit string. Must come before send or quit option. By default, nothing added to send, \r\n added to end of quit
+  -W, --error-warning           Set the error level to warning when exiting with unexpected error (default: critical). In the case of request succeeded, evaluation result of -c option eval takes priority.
+      --no-restime-success-msg  Do not output response time on success. Omissioning success report in mackerel-agent.
 ```
 
 ## For more information


### PR DESCRIPTION
- Do not output response time on success.
- Omissioning success report in mackerel-agent.
  ref. https://github.com/mackerelio/mackerel-agent/blob/1e7a38a/command/command.go#L465-L468