### PR TITLE
Improve tests for check-mysql

### DIFF
--- a/check-mysql/test-tls.sh
+++ b/check-mysql/test-tls.sh
@@ -26,17 +26,7 @@ docker run -d \
 	-e "MYSQL_ROOT_PASSWORD=$password" "$image"
 trap 'docker stop test-$plugin; docker rm test-$plugin; rm $cacert; exit 1' 1 2 3 15
 
-# wait until bootstrap mysqld..
-for i in $(seq 10)
-do
-	echo "Connecting $i..."
-	if $plugin connection --port $port --password $password >/dev/null 2>&1
-	then
-		break
-	fi
-	sleep 3
-done
-sleep 1
+USER=root PASSWORD=$password PORT=$port ./wait.sh
 
 docker cp "test-$plugin:/var/lib/mysql/ca.pem" "$cacert"
 

--- a/check-mysql/test-tls.sh
+++ b/check-mysql/test-tls.sh
@@ -8,7 +8,6 @@ then
 fi
 
 cd "$(dirname "$0")" || exit
-PATH=$(pwd):$PATH
 plugin=$(basename "$(pwd)")
 if ! which "$plugin" >/dev/null
 then

--- a/check-mysql/test.sh
+++ b/check-mysql/test.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+set -ex
+
+./test_57/test.sh
+./test_8/test.sh

--- a/check-mysql/test.sh
+++ b/check-mysql/test.sh
@@ -8,3 +8,4 @@ export PATH=$(pwd):$PATH
 
 ./test_57/test.sh
 ./test_8/test.sh
+./test-tls.sh

--- a/check-mysql/test.sh
+++ b/check-mysql/test.sh
@@ -2,5 +2,9 @@
 
 set -ex
 
+cd "$(dirname "$0")"
+
+export PATH=$(pwd):$PATH
+
 ./test_57/test.sh
 ./test_8/test.sh

--- a/check-mysql/test_57/docker-compose.yml
+++ b/check-mysql/test_57/docker-compose.yml
@@ -3,6 +3,7 @@ version: '3.1'
 services:
   primary:
     image: mysql:5.7.8
+    platform: linux/amd64
     environment:
       MYSQL_ROOT_PASSWORD: mysql
     command:
@@ -17,6 +18,7 @@ services:
 
   replica:
     image: mysql:5.7.8
+    platform: linux/amd64
     environment:
       MYSQL_ROOT_PASSWORD: mysql
     command:

--- a/check-mysql/test_57/docker-compose.yml
+++ b/check-mysql/test_57/docker-compose.yml
@@ -17,8 +17,6 @@ services:
 
   replica:
     image: mysql:5.7.8
-    ports:
-      - 23306:3306
     environment:
       MYSQL_ROOT_PASSWORD: mysql
     command:
@@ -27,3 +25,5 @@ services:
       - --bind_address=0.0.0.0
       - --log_bin=bin.log
       - --read_only=1
+    ports:
+      - 23306:3306

--- a/check-mysql/test_57/test.sh
+++ b/check-mysql/test_57/test.sh
@@ -40,7 +40,7 @@ fi
 
 sleep 2
 
-if ! $plugin uptime --host=127.0.0.1 --port=$primary_port --user=$user --password=$password --critical=2 --warning=1; then
+if ! $plugin uptime --host=127.0.0.1 --port=$primary_port --user=$user --password=$password --critical=1 --warning=2; then
 	echo 'FAIL: uptime should be OK'
 	exit 1
 fi

--- a/check-mysql/test_57/test.sh
+++ b/check-mysql/test_57/test.sh
@@ -38,6 +38,8 @@ if ! $plugin connection --host=127.0.0.1 --port=$primary_port --user=$user --pas
 	exit 1
 fi
 
+sleep 2
+
 if ! $plugin uptime --host=127.0.0.1 --port=$primary_port --user=$user --password=$password --critical=2 --warning=1; then
 	echo 'FAIL: uptime should be OK'
 	exit 1

--- a/check-mysql/test_57/test.sh
+++ b/check-mysql/test_57/test.sh
@@ -79,6 +79,9 @@ mysql -u$user -p$password --host 127.0.0.1 --port=$replica_port -e """
 START SLAVE USER='repl' PASSWORD='repl';
 """
 
+# starting replication may take a while
+sleep 1
+
 if ! $plugin replication --host=127.0.0.1 --port=$replica_port --user=$user --password=$password; then
 	echo 'FAIL: replication of replica server should be started'
 	exit 1

--- a/check-mysql/test_57/test.sh
+++ b/check-mysql/test_57/test.sh
@@ -18,7 +18,6 @@ then
 	exit 2
 fi
 
-sleep_time=30
 user=root
 password=mysql
 primary_port=13306
@@ -30,9 +29,9 @@ if $plugin connection --host=127.0.0.1 --port=$primary_port --user=$user --passw
 fi
 
 docker-compose up -d
-
 trap 'docker-compose down --rmi local -v' EXIT
-sleep $sleep_time
+
+USER=$user PASSWORD=$password PORT=$primary_port ../wait.sh
 
 if ! $plugin connection --host=127.0.0.1 --port=$primary_port --user=$user --password=$password; then
 	echo 'FAIL: connection should be OK'

--- a/check-mysql/test_57/test.sh
+++ b/check-mysql/test_57/test.sh
@@ -12,7 +12,7 @@ fi
 
 cd $(dirname $0)
 plugin=$(basename $(realpath ../))
-if ! which -s $plugin
+if ! which "$plugin" >/dev/null
 then
 	echo "$prog: $plugin is not installed" >&2
 	exit 2

--- a/check-mysql/test_8/docker-compose.yml
+++ b/check-mysql/test_8/docker-compose.yml
@@ -17,8 +17,6 @@ services:
 
   replica:
     image: mysql:8.0.23
-    ports:
-      - 23306:3306
     environment:
       MYSQL_ROOT_PASSWORD: mysql
     command:
@@ -27,3 +25,5 @@ services:
       - --bind_address=0.0.0.0
       - --log_bin=bin.log
       - --read_only=1
+    ports:
+      - 23306:3306

--- a/check-mysql/test_8/docker-compose.yml
+++ b/check-mysql/test_8/docker-compose.yml
@@ -3,6 +3,7 @@ version: '3.1'
 services:
   primary:
     image: mysql:8.0.23
+    platform: linux/amd64
     environment:
       MYSQL_ROOT_PASSWORD: mysql
     command:
@@ -17,6 +18,7 @@ services:
 
   replica:
     image: mysql:8.0.23
+    platform: linux/amd64
     environment:
       MYSQL_ROOT_PASSWORD: mysql
     command:

--- a/check-mysql/test_8/test.sh
+++ b/check-mysql/test_8/test.sh
@@ -40,7 +40,7 @@ fi
 
 sleep 2
 
-if ! $plugin uptime --host=127.0.0.1 --port=$primary_port --user=$user --password=$password --critical=2 --warning=1; then
+if ! $plugin uptime --host=127.0.0.1 --port=$primary_port --user=$user --password=$password --critical=1 --warning=2; then
 	echo 'FAIL: uptime should be OK'
 	exit 1
 fi

--- a/check-mysql/test_8/test.sh
+++ b/check-mysql/test_8/test.sh
@@ -18,7 +18,6 @@ then
 	exit 2
 fi
 
-sleep_time=35
 user=root
 password=mysql
 primary_port=13306
@@ -30,9 +29,9 @@ if $plugin connection --host=127.0.0.1 --port=$primary_port --user=$user --passw
 fi
 
 docker-compose up -d
-
 trap 'docker-compose down --rmi local -v' EXIT
-sleep $sleep_time
+
+USER=$user PASSWORD=$password PORT=$primary_port ../wait.sh
 
 if ! $plugin connection --host=127.0.0.1 --port=$primary_port --user=$user --password=$password; then
 	echo 'FAIL: connection should be OK'

--- a/check-mysql/test_8/test.sh
+++ b/check-mysql/test_8/test.sh
@@ -79,6 +79,9 @@ mysql -u$user -p$password --host 127.0.0.1 --port=$replica_port -e """
 START REPLICA USER='repl' PASSWORD='repl';
 """
 
+# starting replication may take a while
+sleep 1
+
 if ! $plugin replication --host=127.0.0.1 --port=$replica_port --user=$user --password=$password; then
 	echo 'FAIL: replication of replica server should be started'
 	exit 1

--- a/check-mysql/test_8/test.sh
+++ b/check-mysql/test_8/test.sh
@@ -38,6 +38,8 @@ if ! $plugin connection --host=127.0.0.1 --port=$primary_port --user=$user --pas
 	exit 1
 fi
 
+sleep 2
+
 if ! $plugin uptime --host=127.0.0.1 --port=$primary_port --user=$user --password=$password --critical=2 --warning=1; then
 	echo 'FAIL: uptime should be OK'
 	exit 1

--- a/check-mysql/test_8/test.sh
+++ b/check-mysql/test_8/test.sh
@@ -12,7 +12,7 @@ fi
 
 cd $(dirname $0)
 plugin=$(basename $(realpath ../))
-if ! which -s $plugin
+if ! which "$plugin" >/dev/null
 then
 	echo "$prog: $plugin is not installed" >&2
 	exit 2

--- a/check-mysql/wait.sh
+++ b/check-mysql/wait.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+# wait until bootstrap mysqld.. (max = 60s)
+for i in $(seq 20)
+do
+	echo "Connecting $i..."
+	if mysql -u"$USER" -p"$PASSWORD" --host=127.0.0.1 --port="$PORT" -e"select 1" >/dev/null; then
+		break
+	fi
+	sleep 3
+done
+sleep 1

--- a/test.bash
+++ b/test.bash
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # prepare tests
-for f in check-*/test.sh check-*/test-*.sh
+for f in check-*/test.sh
 do
 	dir=$(dirname "$f")
 	name=$(basename "$dir")
@@ -11,7 +11,7 @@ done
 # run tests
 declare -A plugins=()
 declare -a pids=()
-for f in check-*/test.sh check-*/test-*.sh
+for f in check-*/test.sh
 do
 	./"$f" &
 	pid=$!


### PR DESCRIPTION
- Specify docker platform explicitly so that they can be run on Docker Desktop for Mac on Apple silicon
- Run all tests on CI
  - Because of this, it takes about 1 minute longer than before (but I think it's acceptable)
- Fix some unstable tests
- Refactor test scripts