### PR TITLE
added compile option, fix packaging format

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ testconvention:
 build:
 	mkdir -p build
 	for i in $(filter-out check-windows-%, $(wildcard check-*)); do \
-	  go build -ldflags "-s -w" -o build/$$i \
+	  CGO_ENABLED=0 go build -ldflags "-s -w" -o build/$$i \
 	  `pwd | sed -e "s|${GOPATH_ROOT}/src/||"`/$$i; \
 	done
 

--- a/packaging/deb-v2/debian/rules
+++ b/packaging/deb-v2/debian/rules
@@ -6,6 +6,9 @@
 # This variable must be the same as the value of the `Package:` field in the control file.
 package=mackerel-check-plugins
 
+override_dh_builddeb:
+	dh_builddeb -- -Zxz
+
 override_dh_auto_install:
 	dh_auto_install
 	install -d -m 755 debian/${package}/usr/bin

--- a/packaging/deb/debian/rules
+++ b/packaging/deb/debian/rules
@@ -5,6 +5,9 @@
 
 package=mackerel-check-plugins
 
+override_dh_builddeb:
+	dh_builddeb -- -Zxz
+
 override_dh_auto_install:
 	dh_auto_install
 	install -d -m 755 debian/${package}/usr/bin


### PR DESCRIPTION
Changed to use xz format for compressing debian packages. refer https://github.com/mackerelio/mackerel-agent-plugins/pull/981

The environment ubuntu-latest for GitHub Actions is ubuntu 22.04.
It turns out that glibc is new and the built binary compatibility is broken in some environments.
So I made a change to build with CGO_ENABLED=0