### PR TITLE
test: use `T.TempDir` to create temporary test directory

### DIFF
--- a/check-log/lib/check-log_test.go
+++ b/check-log/lib/check-log_test.go
@@ -85,13 +85,7 @@ func TestGetBytesToSkip(t *testing.T) {
 }
 
 func TestSearchReader(t *testing.T) {
-	dir, err := ioutil.TempDir("", "check-log-test")
-	if err != nil {
-		t.Fatalf("TempDir failed: %s", err)
-	}
-	t.Cleanup(func() {
-		os.RemoveAll(dir)
-	})
+	dir := t.TempDir()
 
 	opts := &logOpts{
 		StateDir: dir,
@@ -106,7 +100,7 @@ FATAL 22
 Fatal
 `
 	r := strings.NewReader(content)
-	warnNum, critNum, readBytes, errLines, err := opts.searchReader(context.Background(), r)
+	warnNum, critNum, readBytes, errLines, _ := opts.searchReader(context.Background(), r)
 
 	assert.Equal(t, int64(2), warnNum, "warnNum should be 2")
 	assert.Equal(t, int64(2), critNum, "critNum should be 2")
@@ -115,13 +109,7 @@ Fatal
 }
 
 func TestScenario(t *testing.T) {
-	dir, err := ioutil.TempDir("", "check-log-test")
-	if err != nil {
-		t.Fatalf("something went wrong")
-	}
-	t.Cleanup(func() {
-		os.RemoveAll(dir)
-	})
+	dir := t.TempDir()
 
 	logf := filepath.Join(dir, "dummy")
 	fh, _ := os.Create(logf)
@@ -320,13 +308,7 @@ func (r *slowReader) Read(p []byte) (int, error) {
 }
 
 func TestRunWithGlob(t *testing.T) {
-	dir, err := ioutil.TempDir("", "check-log-test")
-	if err != nil {
-		t.Errorf("something went wrong")
-	}
-	t.Cleanup(func() {
-		os.RemoveAll(dir)
-	})
+	dir := t.TempDir()
 
 	logf1 := filepath.Join(dir, "dummy1")
 	fh1, _ := os.Create(logf1)
@@ -370,15 +352,9 @@ func TestRunWithGlob(t *testing.T) {
 }
 
 func TestRunWithZGlob(t *testing.T) {
-	dir, err := ioutil.TempDir("", "check-log-test")
-	if err != nil {
-		t.Errorf("something went wrong")
-	}
-	t.Cleanup(func() {
-		os.RemoveAll(dir)
-	})
+	dir := t.TempDir()
 
-	err = os.MkdirAll(filepath.Join(dir, "subdir"), 0755)
+	err := os.MkdirAll(filepath.Join(dir, "subdir"), 0755)
 	if err != nil {
 		t.Errorf("something went wrong")
 	}
@@ -425,13 +401,7 @@ func TestRunWithZGlob(t *testing.T) {
 }
 
 func TestRunWithMiddleOfLine(t *testing.T) {
-	dir, err := ioutil.TempDir("", "check-log-test")
-	if err != nil {
-		t.Errorf("something went wrong")
-	}
-	t.Cleanup(func() {
-		os.RemoveAll(dir)
-	})
+	dir := t.TempDir()
 
 	logf := filepath.Join(dir, "dummy")
 	fh, _ := os.Create(logf)
@@ -474,13 +444,7 @@ func TestRunWithMiddleOfLine(t *testing.T) {
 }
 
 func TestRunWithNoState(t *testing.T) {
-	dir, err := ioutil.TempDir("", "check-log-test")
-	if err != nil {
-		t.Errorf("something went wrong")
-	}
-	t.Cleanup(func() {
-		os.RemoveAll(dir)
-	})
+	dir := t.TempDir()
 
 	logf := filepath.Join(dir, "dummy")
 	fh, _ := os.Create(logf)
@@ -516,13 +480,7 @@ func TestRunWithNoState(t *testing.T) {
 }
 
 func TestSearchReaderWithLevel(t *testing.T) {
-	dir, err := ioutil.TempDir("", "check-log-test")
-	if err != nil {
-		t.Errorf("something went wrong")
-	}
-	t.Cleanup(func() {
-		os.RemoveAll(dir)
-	})
+	dir := t.TempDir()
 
 	logf := filepath.Join(dir, "dummy")
 	ptn := `FATAL level:([0-9]+)`
@@ -550,7 +508,7 @@ FATAL level:22
 Fatal level:17
 `
 	r := strings.NewReader(content)
-	warnNum, critNum, readBytes, errLines, err := opts.searchReader(context.Background(), r)
+	warnNum, critNum, readBytes, errLines, _ := opts.searchReader(context.Background(), r)
 
 	assert.Equal(t, int64(2), warnNum, "warnNum should be 2")
 	assert.Equal(t, int64(1), critNum, "critNum should be 1")
@@ -559,13 +517,7 @@ Fatal level:17
 }
 
 func TestRunWithEncoding(t *testing.T) {
-	dir, err := ioutil.TempDir("", "check-log-test")
-	if err != nil {
-		t.Errorf("something went wrong")
-	}
-	t.Cleanup(func() {
-		os.RemoveAll(dir)
-	})
+	dir := t.TempDir()
 
 	logf := filepath.Join(dir, "dummy")
 	fh, _ := os.Create(logf)
@@ -601,13 +553,7 @@ func TestRunWithEncoding(t *testing.T) {
 }
 
 func TestRunWithoutEncoding(t *testing.T) {
-	dir, err := ioutil.TempDir("", "check-log-test")
-	if err != nil {
-		t.Errorf("something went wrong")
-	}
-	t.Cleanup(func() {
-		os.RemoveAll(dir)
-	})
+	dir := t.TempDir()
 
 	logf := filepath.Join(dir, "dummy")
 	fh, _ := os.Create(logf)
@@ -640,13 +586,7 @@ func TestRunWithoutEncoding(t *testing.T) {
 }
 
 func TestRunWithMissingOk(t *testing.T) {
-	dir, err := ioutil.TempDir("", "check-log-test")
-	if err != nil {
-		t.Errorf("something went wrong")
-	}
-	t.Cleanup(func() {
-		os.RemoveAll(dir)
-	})
+	dir := t.TempDir()
 
 	logf := filepath.Join(dir, "dummy")
 
@@ -665,13 +605,7 @@ func TestRunWithMissingOk(t *testing.T) {
 }
 
 func TestRunWithMissingWarning(t *testing.T) {
-	dir, err := ioutil.TempDir("", "check-log-test")
-	if err != nil {
-		t.Errorf("something went wrong")
-	}
-	t.Cleanup(func() {
-		os.RemoveAll(dir)
-	})
+	dir := t.TempDir()
 
 	logf := filepath.Join(dir, "dummy")
 
@@ -690,13 +624,7 @@ func TestRunWithMissingWarning(t *testing.T) {
 }
 
 func TestRunWithMissingCritical(t *testing.T) {
-	dir, err := ioutil.TempDir("", "check-log-test")
-	if err != nil {
-		t.Errorf("something went wrong")
-	}
-	t.Cleanup(func() {
-		os.RemoveAll(dir)
-	})
+	dir := t.TempDir()
 
 	logf := filepath.Join(dir, "dummy")
 
@@ -715,13 +643,7 @@ func TestRunWithMissingCritical(t *testing.T) {
 }
 
 func TestRunWithMissingUnknown(t *testing.T) {
-	dir, err := ioutil.TempDir("", "check-log-test")
-	if err != nil {
-		t.Errorf("something went wrong")
-	}
-	t.Cleanup(func() {
-		os.RemoveAll(dir)
-	})
+	dir := t.TempDir()
 
 	logf := filepath.Join(dir, "dummy")
 
@@ -740,13 +662,7 @@ func TestRunWithMissingUnknown(t *testing.T) {
 }
 
 func TestRunWithGlobAndMissingWarning(t *testing.T) {
-	dir, err := ioutil.TempDir("", "check-log-test")
-	if err != nil {
-		t.Errorf("something went wrong")
-	}
-	t.Cleanup(func() {
-		os.RemoveAll(dir)
-	})
+	dir := t.TempDir()
 
 	logfGlob := filepath.Join(dir, "dummy*")
 
@@ -765,13 +681,7 @@ func TestRunWithGlobAndMissingWarning(t *testing.T) {
 }
 
 func TestRunMultiplePattern(t *testing.T) {
-	dir, err := ioutil.TempDir("", "check-log-test")
-	if err != nil {
-		t.Errorf("something went wrong")
-	}
-	t.Cleanup(func() {
-		os.RemoveAll(dir)
-	})
+	dir := t.TempDir()
 
 	logf := filepath.Join(dir, "dummy")
 	fh, _ := os.Create(logf)
@@ -836,13 +746,7 @@ func TestRunMultiplePattern(t *testing.T) {
 }
 
 func TestRunWithSuppressOption(t *testing.T) {
-	dir, err := ioutil.TempDir("", "check-log-test")
-	if err != nil {
-		t.Errorf("something went wrong")
-	}
-	t.Cleanup(func() {
-		os.RemoveAll(dir)
-	})
+	dir := t.TempDir()
 
 	logf := filepath.Join(dir, "dummy")
 	fh, _ := os.Create(logf)
@@ -907,13 +811,7 @@ func TestRunWithSuppressOption(t *testing.T) {
 }
 
 func TestRunMultipleExcludePattern(t *testing.T) {
-	dir, err := ioutil.TempDir("", "check-log-test")
-	if err != nil {
-		t.Errorf("something went wrong")
-	}
-	t.Cleanup(func() {
-		os.RemoveAll(dir)
-	})
+	dir := t.TempDir()
 
 	logf := filepath.Join(dir, "dummy")
 	fh, _ := os.Create(logf)

--- a/check-log/lib/check-log_unix_test.go
+++ b/check-log/lib/check-log_unix_test.go
@@ -5,7 +5,6 @@ package checklog
 import (
 	"context"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -14,11 +13,7 @@ import (
 )
 
 func TestFindFileByInode(t *testing.T) {
-	dir, err := ioutil.TempDir("", "check-log-test")
-	if err != nil {
-		t.Errorf("something went wrong")
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	logf := filepath.Join(dir, "dummy")
 	fh, _ := os.Create(logf)
@@ -42,11 +37,7 @@ func TestFindFileByInode(t *testing.T) {
 }
 
 func TestOpenOldFile(t *testing.T) {
-	dir, err := ioutil.TempDir("", "check-log-test")
-	if err != nil {
-		t.Fatalf("TempDir failed: %s", err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	logf := filepath.Join(dir, "dummy")
 	fh, _ := os.Create(logf)
@@ -83,11 +74,7 @@ func TestOpenOldFile(t *testing.T) {
 
 	testFoundOldFileByInode := func() {
 		// dir different from logf
-		dir, err := ioutil.TempDir("", "check-log-test")
-		if err != nil {
-			t.Fatalf("TempDir failed: %s", err)
-		}
-		defer os.RemoveAll(dir)
+		dir := t.TempDir()
 		ologf := filepath.Join(dir, "dummy.1")
 
 		ofh, _ := os.Create(ologf)
@@ -104,11 +91,7 @@ func TestOpenOldFile(t *testing.T) {
 }
 
 func TestRunTraceInode(t *testing.T) {
-	dir, err := ioutil.TempDir("", "check-log-test")
-	if err != nil {
-		t.Errorf("something went wrong")
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	logf := filepath.Join(dir, "dummy")
 	fh, _ := os.Create(logf)

--- a/check-tcp/lib/check-tcp_test.go
+++ b/check-tcp/lib/check-tcp_test.go
@@ -3,7 +3,6 @@ package checktcp
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -225,11 +224,7 @@ func TestUnixDomainSocket(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("skipping test on windows")
 	}
-	dir, err := ioutil.TempDir(os.TempDir(), "")
-	if err != nil {
-		t.Error(err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	sock := fmt.Sprintf("%s/test.sock", dir)
 

--- a/check-windows-eventlog/lib/check_windows_eventlog_test.go
+++ b/check-windows-eventlog/lib/check_windows_eventlog_test.go
@@ -3,8 +3,6 @@
 package checkwindowseventlog
 
 import (
-	"io/ioutil"
-	"os"
 	"path/filepath"
 	"reflect"
 	"runtime"
@@ -65,11 +63,7 @@ func raiseEvent(t *testing.T, typ int, msg string) {
 }
 
 func TestRun(t *testing.T) {
-	dir, err := ioutil.TempDir("", "check-windows-eventlog-test")
-	if err != nil {
-		t.Errorf("something went wrong")
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	origArgs := []string{"-s", dir, "--log", "Application"}
 	args := make([]string, len(origArgs))
@@ -207,11 +201,7 @@ func TestRun(t *testing.T) {
 }
 
 func TestPattern(t *testing.T) {
-	dir, err := ioutil.TempDir("", "check-windows-eventlog-test")
-	if err != nil {
-		t.Errorf("something went wrong")
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	opts, _ := parseArgs([]string{"-s", dir, "--log", "Application"})
 	opts.prepare()
@@ -320,11 +310,7 @@ func TestPattern(t *testing.T) {
 }
 
 func TestIDs(t *testing.T) {
-	dir, err := ioutil.TempDir("", "check-windows-eventlog-test")
-	if err != nil {
-		t.Errorf("something went wrong")
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	opts, _ := parseArgs([]string{"-s", dir, "--log", "Application"})
 	opts.prepare()
@@ -343,7 +329,7 @@ func TestIDs(t *testing.T) {
 		writeLastOffset(stateFile, lastNumber)
 	}
 
-	_, _, _, err = opts.searchLog("Application")
+	_, _, _, err := opts.searchLog("Application")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -396,11 +382,7 @@ func TestIDs(t *testing.T) {
 }
 
 func TestFailFirst(t *testing.T) {
-	dir, err := ioutil.TempDir("", "check-windows-eventlog-test")
-	if err != nil {
-		t.Errorf("something went wrong")
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	opts, _ := parseArgs([]string{"-s", dir, "--log", "Application", "--fail-first", "--warning-over", "0", "--critical-over", "0"})
 	opts.prepare()


### PR DESCRIPTION
A testing cleanup. 

This pull request replaces `ioutil.TempDir` with `t.TempDir`. We can use the `T.TempDir` function from the `testing` package to create temporary directory. The directory created by `T.TempDir` is automatically removed when the test and all its subtests complete. 

This saves us at least 2 lines (error check, and cleanup) on every instance.

Reference: https://pkg.go.dev/testing#T.TempDir

```go
func TestFoo(t *testing.T) {
	// before
	tmpDir, err := ioutil.TempDir("", "")
	if err != nil {
		t.Fatal(err)
	}
	defer os.RemoveAll(tmpDir)

	// now
	tmpDir := t.TempDir()
}
```