### PR TITLE
Enables Dependabot version updates for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,15 @@
 version: 2
 updates:
-- package-ecosystem: gomod
-  directory: "/"
-  schedule:
-    interval: weekly
-    time: "01:00"
-    timezone: Asia/Tokyo
-  open-pull-requests-limit: 10
+  - package-ecosystem: gomod
+    directory: "/"
+    schedule:
+      interval: weekly
+      time: "01:00"
+      timezone: Asia/Tokyo
+    open-pull-requests-limit: 10
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+      time: "01:00"
+      timezone: Asia/Tokyo

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -1,9 +1,9 @@
-name: 'Create Release PR'
+name: "Create Release PR"
 on:
   workflow_dispatch:
     inputs:
       release_version:
-        description: 'next release version'
+        description: "next release version"
         required: true
 env:
   GIT_AUTHOR_NAME: mackerelbot
@@ -19,7 +19,7 @@ jobs:
 
       - uses: shogo82148/actions-setup-perl@v1
         with:
-          perl-version: '5.34'
+          perl-version: "5.34"
 
       - uses: mackerelio/mackerel-create-release-pull-request-action@main
         id: start
@@ -46,4 +46,3 @@ jobs:
           next_version: ${{ steps.start.outputs.nextVersion }}
           branch_name: ${{ steps.start.outputs.branchName }}
           pull_request_infos: ${{ steps.start.outputs.pullRequestInfos }}
-


### PR DESCRIPTION
This repository's workflows look antiquated. Deprecated features and runtimes of Github Actions will soon be unavailable.

So we activate dependabot for GitHub Actions to automate updates.