### PR TITLE
check-dns: add expected-address option

### DIFF
--- a/check-dns/README.md
+++ b/check-dns/README.md
@@ -5,8 +5,29 @@
 Monitor DNS response.
 
 ## Synopsis
+
+Check DNS server status  
+If DNS server returns  
+```
+NOERROR   -> OK  
+otherwise -> CRITICAL
+```
 ```
 check-dns -H example.com -s 8.8.8.8
+```
+
+Check IP-ADDRESS DNS server returns  
+If DNS server returns 1.1.1.1 and 2.2.2.2
+```
+-a 1.1.1.1, 2.2.2.2          -> OK  
+-a 1.1.1.1, 2.2.2.2, 3.3.3.3 -> WARNING  
+-a 1.1.1.1                   -> WARNING  
+-a 1.1.1.1, 3.3.3.3          -> WARNING  
+-a 3.3.3.3                   -> CRITICAL  
+-a 3.3.3.3, 4.4.4.4, 5.5.5.5 -> CRITICAL  
+```
+```
+check-dns -H example.com -s 8.8.8.8 -a 93.184.216.34
 ```
 
 ## Installation
@@ -42,12 +63,13 @@ command = ["check-dns", "-H", "example.com", "-s", "8.8.8.8"]
 ### Options
 
 ```
-  -H, --host=       The name or address you want to query
-  -s, --server=     DNS server you want to use for the lookup
-  -p, --port=       Port number you want to use (default: 53)
-  -q, --querytype=  DNS record query type where TYPE =(A, AAAA, SRV, TXT, MX, ANY) (default: A)
-  -c, --queryclass= DNS record class type where TYPE =(IN, CS, CH, HS, NONE, ANY) (default: IN)
-      --norec       Set not recursive mode
+  -H, --host=             The name or address you want to query
+  -s, --server=           DNS server you want to use for the lookup
+  -p, --port=             Port number you want to use (default: 53)
+  -q, --querytype=        DNS record query type where TYPE =(A, AAAA, SRV, TXT, MX, ANY) (default: A)
+  -c, --queryclass=       DNS record class type where TYPE =(IN, CS, CH, HS, NONE, ANY) (default: IN)
+      --norec             Set not recursive mode
+  -a, --expected-address= IP-ADDRESS you expect the DNS server to return. If multiple addresses are returned at once, you have to match the whole string of addresses separated with commas
 ```
 
 ## For more information

--- a/check-dns/lib/check_dns.go
+++ b/check-dns/lib/check_dns.go
@@ -13,12 +13,13 @@ import (
 )
 
 type dnsOpts struct {
-	Host       string `short:"H" long:"host" required:"true" description:"The name or address you want to query"`
-	Server     string `short:"s" long:"server" description:"DNS server you want to use for the lookup"`
-	Port       int    `short:"p" long:"port" default:"53" description:"Port number you want to use"`
-	QueryType  string `short:"q" long:"querytype" default:"A" description:"DNS record query type where TYPE =(A, AAAA, SRV, TXT, MX, ANY)"`
-	QueryClass string `short:"c" long:"queryclass" default:"IN" description:"DNS record class type where TYPE =(IN, CS, CH, HS, NONE, ANY)"`
-	Norec      bool   `long:"norec" description:"Set not recursive mode"`
+	Host            string `short:"H" long:"host" required:"true" description:"The name or address you want to query"`
+	Server          string `short:"s" long:"server" description:"DNS server you want to use for the lookup"`
+	Port            int    `short:"p" long:"port" default:"53" description:"Port number you want to use"`
+	QueryType       string `short:"q" long:"querytype" default:"A" description:"DNS record query type where TYPE =(A, AAAA, SRV, TXT, MX, ANY)"`
+	QueryClass      string `short:"c" long:"queryclass" default:"IN" description:"DNS record class type where TYPE =(IN, CS, CH, HS, NONE, ANY)"`
+	Norec           bool   `long:"norec" description:"Set not recursive mode"`
+	ExpectedAddress string `short:"a" long:"expected-address" description:"IP-ADDRESS you expect the DNS server to return. If multiple addresses are returned at once, you have to match the whole string of addresses separated with commas"`
 }
 
 // Do the plugin
@@ -76,9 +77,44 @@ func (opts *dnsOpts) run() *checkers.Checker {
 	}
 
 	checkSt := checkers.OK
+	/**
+	   if DNS server return 1.1.1.1, 2.2.2.2
+		1: --expected-address 1.1.1.1, 2.2.2.2          -> OK
+		2: --expected-address 1.1.1.1, 2.2.2.2, 3.3.3.3 -> WARNING
+		3: --expected-address 1.1.1.1                   -> WARNING
+		4: --expected-address 1.1.1.1, 3.3.3.3          -> WARNING
+		5: --expected-address 3.3.3.3                   -> CRITICAL
+		6: --expected-address 3.3.3.3, 4.4.4.4, 5.5.5.5 -> CRITICAL
+	**/
+	if opts.ExpectedAddress != "" {
+		expectedAddress := strings.Split(opts.ExpectedAddress, ",")
+		match := 0
+		for _, v := range expectedAddress {
+			for _, answer := range r.Answer {
+				if strings.Contains(answer.String(), strings.TrimSpace(v)) {
+					match += 1
+				}
+			}
+		}
+		if match == len(r.Answer) {
+			if len(expectedAddress) == len(r.Answer) { // case 1
+				checkSt = checkers.OK
+			} else { // case 2
+				checkSt = checkers.WARNING
+			}
+		} else {
+			if match > 0 { // case 3,4
+				checkSt = checkers.WARNING
+			} else { // case 5,6
+				checkSt = checkers.CRITICAL
+			}
+		}
+	}
+
 	if r.MsgHdr.Rcode != dns.RcodeSuccess {
 		checkSt = checkers.CRITICAL
 	}
+
 	msg := fmt.Sprintf("HEADER-> %s\n", r.MsgHdr.String())
 	for _, answer := range r.Answer {
 		msg += fmt.Sprintf("ANSWER-> %s\n", answer)

--- a/check-dns/lib/check_dns_test.go
+++ b/check-dns/lib/check_dns_test.go
@@ -78,6 +78,36 @@ func TestCheckDns(t *testing.T) {
 			checkers.CRITICAL,
 			[]string{"INN is invalid queryClass"},
 		},
+		{
+			[]string{"-H", "example.com", "-s", "8.8.8.8", "-a", "93.184.216.34"},
+			checkers.OK,
+			[]string{"status: NOERROR", "93.184.216.34"},
+		},
+		{
+			[]string{"-H", "example.com", "-s", "8.8.8.8", "-q", "AAAA", "--expected-address", "2606:2800:220:1"},
+			checkers.OK,
+			[]string{"status: NOERROR", "2606:2800:220:1"},
+		},
+		{
+			[]string{"-H", "example.com", "-s", "8.8.8.8", "-a", "93.184.216.33"},
+			checkers.CRITICAL,
+			[]string{"status: NOERROR", "93.184.216.34"},
+		},
+		{
+			[]string{"-H", "exampleeeee.com", "-s", "8.8.8.8", "-a", "93.184.216.34"},
+			checkers.CRITICAL,
+			[]string{"status: NXDOMAIN"},
+		},
+		{
+			[]string{"-H", "example.com", "-s", "8.8.8.8", "-a", "93.184.216.33,93.184.216.34"},
+			checkers.WARNING,
+			[]string{"status: NOERROR", "93.184.216.34"},
+		},
+		{
+			[]string{"-H", "example.com", "-s", "8.8.8.8", "-a", "93.184.216.33,    93.184.216.34"},
+			checkers.WARNING,
+			[]string{"status: NOERROR", "93.184.216.34"},
+		},
 	}
 
 	for i, tt := range tests {


### PR DESCRIPTION
```conf
[plugin.checks.check-dns-a]
command = ["/Users/wafuwafu13/Desktop/go-check-plugins/check-dns/check-dns", "-H", "hatenablog.com", "-a", "35.75.255.9, 54.199.90.60"]

[plugin.checks.check-dns-b]
command = ["/Users/wafuwafu13/Desktop/go-check-plugins/check-dns/check-dns", "-H", "hatenablog.com", "-a", "35.75.255.9"]

[plugin.checks.check-dns-c]
command = ["/Users/wafuwafu13/Desktop/go-check-plugins/check-dns/check-dns", "-H", "hatenablog.com", "-a", "35.75.255.8"]

[plugin.checks.check-dns-d]
command = ["/Users/wafuwafu13/Desktop/go-check-plugins/check-dns/check-dns", "-H", "hatenablog.com", "-a", "35.75.255.9, 54.199.90.60, 54.199.90.66"]
```

![スクリーンショット 2023-02-13 10 09 19](https://user-images.githubusercontent.com/50798936/218355551-fba2b261-15c3-4307-9577-fb443581bf54.png)
![スクリーンショット 2023-02-13 10 09 13](https://user-images.githubusercontent.com/50798936/218355559-7825c96d-03eb-4e14-b47a-b0d42ec89774.png)
