### PR TITLE
Improve ntservice

### DIFF
--- a/check-ntservice/README.md
+++ b/check-ntservice/README.md
@@ -42,9 +42,10 @@ command = ["check-ntservice", "--service-name", "SERVICE_NAME"]
 ### Options
 
 ```
-  -s, --service-name=    service name
-  -E, --exclude-service= service name to exclude from matching. This option takes precedence over --service-name
+  -s, --service-name=    matches if contained in service name
+  -E, --exclude-service= exclude if contained in service name. This option takes precedence over --service-name
   -l, --list-service     list service
+  --exact                more exact checking of the service. This option applies only to --service-name.
 ```
 
 

--- a/check-ntservice/lib/check_ntservice.go
+++ b/check-ntservice/lib/check_ntservice.go
@@ -13,6 +13,7 @@ var opts struct {
 	ServiceName    string `long:"service-name" short:"s" description:"service name"`
 	ExcludeService string `long:"exclude-service" short:"x" description:"service name to exclude from matching. This option takes precedence over --service-name"`
 	ListService    bool   `long:"list-service" short:"l" description:"list service"`
+	Exact          bool   `long:"exact" description:"more exact checking of the service. This option applies only to --service-name."`
 }
 
 // Win32Service is struct for Win32_Service.
@@ -58,19 +59,26 @@ func run(args []string) *checkers.Checker {
 		return checkers.Critical(err.Error())
 	}
 
-	checkSt := checkers.OK
-	msg := ""
+	checkSt := checkers.UNKNOWN
+	msg := fmt.Sprintf("%s: service does not exist.", opts.ServiceName)
 	for _, s := range ss {
 		if opts.ExcludeService != "" && strings.Contains(s.Name, opts.ExcludeService) {
 			continue
 		}
-		if !strings.Contains(s.Name, opts.ServiceName) {
-			continue
+		if opts.Exact {
+			if s.Name != opts.ServiceName {
+				continue
+			}
+		} else {
+			if !strings.Contains(s.Name, opts.ServiceName) {
+				continue
+			}
 		}
 		if s.State == "Running" {
-			continue
+			checkSt = checkers.OK
+		} else {
+			checkSt = checkers.CRITICAL
 		}
-		checkSt = checkers.CRITICAL
 		msg = fmt.Sprintf("%s: %s - %s", s.Name, s.Caption, s.State)
 		break
 	}

--- a/check-ntservice/lib/check_ntservice.go
+++ b/check-ntservice/lib/check_ntservice.go
@@ -10,8 +10,8 @@ import (
 )
 
 var opts struct {
-	ServiceName    string `long:"service-name" short:"s" description:"matches if contained in a service name"`
-	ExcludeService string `long:"exclude-service" short:"x" description:"exclude if contained in service name. This option takes precedence over --service-name"`
+	ServiceName    string `long:"service-name" short:"s" description:"matches if contained in service name."`
+	ExcludeService string `long:"exclude-service" short:"x" description:"exclude if contained in service name. This option takes precedence over --service-name."`
 	ListService    bool   `long:"list-service" short:"l" description:"list service"`
 	Exact          bool   `long:"exact" description:"more exact checking of the service. This option applies only to --service-name."`
 }

--- a/check-ntservice/lib/check_ntservice.go
+++ b/check-ntservice/lib/check_ntservice.go
@@ -10,8 +10,8 @@ import (
 )
 
 var opts struct {
-	ServiceName    string `long:"service-name" short:"s" description:"service name"`
-	ExcludeService string `long:"exclude-service" short:"x" description:"service name to exclude from matching. This option takes precedence over --service-name"`
+	ServiceName    string `long:"service-name" short:"s" description:"matches if contained in a service name"`
+	ExcludeService string `long:"exclude-service" short:"x" description:"exclude if contained in service name. This option takes precedence over --service-name"`
 	ListService    bool   `long:"list-service" short:"l" description:"list service"`
 	Exact          bool   `long:"exact" description:"more exact checking of the service. This option applies only to --service-name."`
 }

--- a/check-ntservice/lib/check_ntservice_test.go
+++ b/check-ntservice/lib/check_ntservice_test.go
@@ -89,7 +89,7 @@ func TestRun(t *testing.T) {
 			casename:      "check about running service",
 			cmdline:       []string{"-s", "running-service"},
 			expectStatus:  checkers.OK,
-			expectMessage: "",
+			expectMessage: "running-service-name: running-service-caption - Running",
 		},
 		{
 			casename:      "check about stopped service",
@@ -101,7 +101,25 @@ func TestRun(t *testing.T) {
 			casename:      "check about running service with exclude option",
 			cmdline:       []string{"-s", "service", "-x", "stopped"},
 			expectStatus:  checkers.OK,
-			expectMessage: "",
+			expectMessage: "running-service-name: running-service-caption - Running",
+		},
+		{
+			casename:      "check about unknown service",
+			cmdline:       []string{"-s", "unknown-service-name"},
+			expectStatus:  checkers.UNKNOWN,
+			expectMessage: "unknown-service-name: service does not exist.",
+		},
+		{
+			casename:      "check about running service with --exact option",
+			cmdline:       []string{"-s", "running-service-name", "--exact"},
+			expectStatus:  checkers.OK,
+			expectMessage: "running-service-name: running-service-caption - Running",
+		},
+		{
+			casename:      "check about unmatched service with --exact option",
+			cmdline:       []string{"-s", "service", "--exact"},
+			expectStatus:  checkers.UNKNOWN,
+			expectMessage: "service: service does not exist.",
 		},
 	}
 


### PR DESCRIPTION
The following problems with check-ntservice have been corrected

- Since the service name determination is a partial match, the intended service may not be checked, so an `--exact` option to check with a full matched by `--service-name` has been added.
- Since all services were checked, the last checked result was returned. This has been corrected to return the result of the first check.
- When a nonexistent service is specified, it is now set to UNKNOWN.
- Improved the message to include the service name even if the result is OK.
- Fixed command description.

When this fix is merged, existing users may be affected as follows.

- A result that was OK without matching service may become UNKNOWN. This is a correct condition.
- If multiple services are matched, the result of the first service matched will be returned. This is also the correct state from the perspective of checking for a specific service.