### PR TITLE
[check-tcp] Supports option to monitor that ports are closed.

### DIFF
--- a/check-tcp/README.md
+++ b/check-tcp/README.md
@@ -58,6 +58,7 @@ command = ["check-tcp", "-H", "localhost", "-p", "4224", "-w", "3", "-c", "5"]
   -c, --critical=             Response time to result in critical status (seconds)
   -E, --escape                Can use \n, \r, \t or \ in send or quit string. Must come before send or quit option. By default, nothing added to send, \r\n added to end of quit
   -W, --error-warning         Set the error level to warning when exiting with unexpected error (default: critical). In the case of request succeeded, evaluation result of -c option eval takes priority.
+  -C, --expect-closed         Verify that the port/unixsock is closed. If the port/unixsock is closed, OK; if open, follow the ErrWarning flag. This option only verifies the connection.
 ```
 
 ## For more information

--- a/check-tcp/lib/check-tcp.go
+++ b/check-tcp/lib/check-tcp.go
@@ -18,13 +18,14 @@ type tcpOpts struct {
 	Service  string `long:"service" description:"Service name. e.g. ftp, smtp, pop, imap and so on"`
 	Hostname string `short:"H" long:"hostname" description:"Host name or IP Address"`
 	exchange
-	Timeout    float64 `short:"t" long:"timeout" default:"10" description:"Seconds before connection times out"`
-	MaxBytes   int     `short:"m" long:"maxbytes" description:"Close connection once more than this number of bytes are received"`
-	Delay      float64 `short:"d" long:"delay" description:"Seconds to wait between sending string and polling for response"`
-	Warning    float64 `short:"w" long:"warning" description:"Response time to result in warning status (seconds)"`
-	Critical   float64 `short:"c" long:"critical" description:"Response time to result in critical status (seconds)"`
-	Escape     bool    `short:"E" long:"escape" description:"Can use \\n, \\r, \\t or \\ in send or quit string. Must come before send or quit option. By default, nothing added to send, \\r\\n added to end of quit"`
-	ErrWarning bool    `short:"W" long:"error-warning" description:"Set the error level to warning when exiting with unexpected error (default: critical). In the case of request succeeded, evaluation result of -c option eval takes priority."`
+	Timeout      float64 `short:"t" long:"timeout" default:"10" description:"Seconds before connection times out"`
+	MaxBytes     int     `short:"m" long:"maxbytes" description:"Close connection once more than this number of bytes are received"`
+	Delay        float64 `short:"d" long:"delay" description:"Seconds to wait between sending string and polling for response"`
+	Warning      float64 `short:"w" long:"warning" description:"Response time to result in warning status (seconds)"`
+	Critical     float64 `short:"c" long:"critical" description:"Response time to result in critical status (seconds)"`
+	Escape       bool    `short:"E" long:"escape" description:"Can use \\n, \\r, \\t or \\ in send or quit string. Must come before send or quit option. By default, nothing added to send, \\r\\n added to end of quit"`
+	ErrWarning   bool    `short:"W" long:"error-warning" description:"Set the error level to warning when exiting with unexpected error (default: critical). In the case of request succeeded, evaluation result of -c option eval takes priority."`
+	ExpectClosed bool    `short:"C" long:"expect-closed" description:"Verify that the port/unixsock is closed. If the port/unixsock is closed, OK; if open, follow the ErrWarning flag. This option only verifies the connection."`
 }
 
 type exchange struct {
@@ -179,12 +180,34 @@ func (opts *tcpOpts) run() *checkers.Checker {
 
 	conn, err := dial(proto, addr, opts.SSL, opts.NoCheckCertificate, timeout)
 	if err != nil {
+		if opts.ExpectClosed {
+			var msg string
+			if opts.UnixSock == "" {
+				msg = fmt.Sprintf("Verified that the port is closed. (port=%d)", opts.Port)
+			} else {
+				msg = fmt.Sprintf("Verified that the unixsock is closed. (sock=%s)", opts.UnixSock)
+			}
+			return checkers.Ok(msg)
+		}
 		if opts.ErrWarning {
 			return checkers.Warning(err.Error())
 		}
 		return checkers.Critical(err.Error())
 	}
 	defer conn.Close()
+
+	if opts.ExpectClosed {
+		var msg string
+		if opts.UnixSock == "" {
+			msg = fmt.Sprintf("Unexpectedly open port. (port=%d)", opts.Port)
+		} else {
+			msg = fmt.Sprintf("Unexpectedly open unixsock. (sock=%s)", opts.UnixSock)
+		}
+		if opts.ErrWarning {
+			return checkers.Warning(msg)
+		}
+		return checkers.Critical(msg)
+	}
 
 	if opts.Send != "" {
 		err := write(conn, []byte(opts.Send), timeout)


### PR DESCRIPTION
TCP connection monitoring is provided by a mechanism that assumes the port is open.

In some cases, it is possible that the state in which the port is closed is correct, and in such cases, the following shell workaround can be used.

```toml
[plugin.checks.dummy]
command = "check-tcp -H <host> -p <port> && exit 2 || exit 0"
```

However, since it is more convenient to be provided as an option, we have added a --expect-closed flag to determine that the state in which the port is closed is normal.

When this option is enabled, it will only work for processes that make connections.