### PR TITLE
check-ntservice: exclude should be -x, not -E

### DIFF
--- a/check-ntservice/README.md
+++ b/check-ntservice/README.md
@@ -43,7 +43,7 @@ command = ["check-ntservice", "--service-name", "SERVICE_NAME"]
 
 ```
   -s, --service-name=    matches if contained in service name
-  -E, --exclude-service= exclude if contained in service name. This option takes precedence over --service-name
+  -x, --exclude-service= exclude if contained in service name. This option takes precedence over --service-name
   -l, --list-service     list service
   --exact                more exact checking of the service. This option applies only to --service-name.
 ```


### PR DESCRIPTION
I found a mistype option in README.md of check-ntservice.
`-E` should be `-x`. (I checked the code and its behavior)
