### PR TITLE
fix the line handling of UTF-16le

### DIFF
--- a/check-log/lib/check-log.go
+++ b/check-log/lib/check-log.go
@@ -353,6 +353,15 @@ func (opts *logOpts) searchReader(ctx context.Context, rdr io.Reader) (warnNum, 
 		readBytes += int64(len(lineBytes))
 
 		if opts.decoder != nil {
+			if opts.Encoding == "UTF-16le" {
+				// Separating UTF-16 little endian lines by byte 0x0a ("\n")
+				// leaves 0x00 at the beginning of second line onwards. Remove it.
+				if lineBytes[0] == 0x00 {
+					lineBytes = lineBytes[1:]
+				}
+				// Since it ends with 0x0a, use 0x0a 0x00 as UTF-16 little endian
+				lineBytes = append(lineBytes, 0x00)
+			}
 			lineBytes, err = opts.decoder.Bytes(lineBytes)
 			if err != nil {
 				break


### PR DESCRIPTION
Hi, I noticed check-log doesn't correctly determnine UTF-16le (Little Endian).

The following problems occur with UTF-16le because log files are separated by "\n" based on bytes rather than based on encoding.

- The newline character 0x0a 0x00 in UTF-16le is delimited in the middle, so the second and subsequent lines contain 0x00 at the beginning.
- Similarly, line endings are broken when converted to UTF-8 because only 0x0a is used instead of 0x0a 0x00

As this does not happen with other encodings (unless you consider UTF-32), it seemed reasonable to deal only with UTF-16le.
I propose a patch here.

Test:
```
[Before patch]
$ go run main.go -p ☺️  -f testcode/t1-u16le.txt --encoding=UTF-16le --check-first -s . --return
LOG CRITICAL: 1 warnings, 1 criticals for pattern /☺️/.
[testcode/t1-u16le.txt]
☺️�

exit status 2

$ go run main.go -p ☺️  -f testcode/t1-u16le-bom.txt --encoding=UTF-16le --check-first -s . --return
LOG CRITICAL: 1 warnings, 1 criticals for pattern /☺️/.
[testcode/t1-u16le-bom.txt]
☺️�

exit status 2

$ go run main.go -p ☺️  -f testcode/t1-u16le-bom-crlf.txt --encoding=UTF-16le --check-first -s . --return
LOG CRITICAL: 1 warnings, 1 criticals for pattern /☺️/.
[testcode/t1-u16le-bom-crlf.txt]
�

exit status 2

[after patch]
$ go run main.go -p ☺️  -f testcode/t1-u16le.txt --encoding=UTF-16le --check-first -s . --return
LOG CRITICAL: 3 warnings, 3 criticals for pattern /☺️/.
[testcode/t1-u16le.txt]
☺️
☺️
☺️

exit status 2

$ go run main.go -p ☺️  -f testcode/t1-u16le-bom.txt --encoding=UTF-16le --check-first -s . --return
LOG CRITICAL: 3 warnings, 3 criticals for pattern /☺️/.
[testcode/t1-u16le-bom.txt]
☺️
☺️
☺️

exit status 2

$ go run main.go -p ☺️  -f testcode/t1-u16le-bom-crlf.txt --encoding=UTF-16le --check-first -s . --return
LOG CRITICAL: 3 warnings, 3 criticals for pattern /☺️/.
[testcode/t1-u16le-bom-crlf.txt]
☺️
☺️
☺️

exit status 2
```

[testcodes.zip](https://github.com/mackerelio/go-check-plugins/files/12973343/testcodes.zip)