### PR TITLE
Fix: check-log panic with invalid memory address or nil pointer dereference

### DIFF
--- a/check-log/lib/check-log.go
+++ b/check-log/lib/check-log.go
@@ -571,6 +571,9 @@ func findFileByInode(inode uint, dir string) (string, error) {
 		if err != nil && !errors.Is(err, os.ErrNotExist) {
 			return "", err
 		}
+		if fi == nil {
+			continue
+		}
 		if detectInode(fi) == inode {
 			return filepath.Join(dir, fi.Name()), nil
 		}


### PR DESCRIPTION
I created the patch https://github.com/mackerelio/go-check-plugins/pull/823 , but this patch has a bug.

Procedure for reproducing : 

- Apply this patch.
  ```diff
  diff --git a/check-log/lib/check-log.go b/check-log/lib/check-log.go
  index f942c58..2efa68e 100644
  --- a/check-log/lib/check-log.go
  +++ b/check-log/lib/check-log.go
  @@ -16,6 +16,7 @@ import (
          "regexp"
          "strconv"
          "strings"
  +       "time"

          "github.com/jessevdk/go-flags"
          "github.com/mackerelio/checkers"
  @@ -566,6 +567,8 @@ var errFileNotFoundByInode = fmt.Errorf("old file not found")

   func findFileByInode(inode uint, dir string) (string, error) {
          entries, readDirErr := os.ReadDir(dir)
  +       fmt.Println("sleeping")
  +       time.Sleep(10 * time.Second)
          for _, entry := range entries {
                  fi, err := entry.Info()
                  if err != nil && !errors.Is(err, os.ErrNotExist) {
  ```
- Create a log file. `touch dummy.log`
- Create a state file. `go run main.go -f ./dummy.log -p error -s $(pwd)`
- Rotate the log file. `mv dummy.log dummy-1.log && touch dummy.log`
- Run check-log. `go run main.go -f ./dummy.log -p error -s $(pwd)`
- When the "sleeping" is printed, remove the rotated log file. `rm dummy-1.log`
- panic