### PR TITLE
return CRITICAL instead of UNKNOWN when check-redis reachable is failed

### DIFF
--- a/check-redis/lib/check-redis.go
+++ b/check-redis/lib/check-redis.go
@@ -139,7 +139,7 @@ func checkReachable(args []string) *checkers.Checker {
 
 	c, info, err := connectRedisGetInfo(opts)
 	if err != nil {
-		return checkers.Unknown(err.Error())
+		return checkers.Critical(err.Error())
 	}
 	defer c.Close()
 

--- a/check-redis/test.sh
+++ b/check-redis/test.sh
@@ -20,6 +20,14 @@ password=passpass
 port=16379
 image=redis:5
 
+RET=$($plugin reachable --port $port --password $password)
+# check-redis should return CRITICAL (exit code 2) when the server is unreachable
+if [ $? -ne 2 ]; then
+	echo "$prog: $plugin returned $? (2 is expected)" >&2
+	exit 2
+fi
+echo "$RET"
+
 docker run --name "test-$plugin" -p "$port:6379" -d "$image" --requirepass "$password"
 trap 'docker stop test-$plugin; docker rm test-$plugin; exit' EXIT
 sleep 10


### PR DESCRIPTION
I believe `check-redis reachable` is intented to check a rechability.
Unlike the expectation of returning OK / CRITICAL, this command returns OK / UNKNOWN.

Here is a proposal patch to change the behavior. This may be breaking change, but it should meet user's expectation.
