### PR TITLE
  fix(check-windows-eventlog): mask EventID to lower 16 bits for display

### DIFF
--- a/check-windows-eventlog/README.md
+++ b/check-windows-eventlog/README.md
@@ -52,7 +52,7 @@ command = ["check-windows-eventlog", "--log", "LOGTYPE", "--type", "EVENTTYPE", 
       --event-id-exclude  Event IDs ignorable (separated by comma, or range)
   -w, --warning-over      Trigger a warning if matched lines is over a number
   -c, --critical-over     Trigger a critical if matched lines is over a number
-  -r, --return            Return matched line
+  -r, --return            Return matched line with custom format. Available placeholders: {{source}}, {{id}}, {{message}} (default format: {{source}}:{{message}})
   -s, --state-dir         Dir to keep state files under
       --no-state          Don't use state file and read whole logs
       --fail-first        Count errors on first seek

--- a/check-windows-eventlog/lib/check-windows-eventlog.go
+++ b/check-windows-eventlog/lib/check-windows-eventlog.go
@@ -371,16 +371,18 @@ loop_events:
 		}
 
 		r := *(*eventlog.EVENTLOGRECORD)(unsafe.Pointer(&buf[0]))
+
+		// event code takes last 2 bytes
+		eventID := r.EventID & 0x0000FFFF
+
 		if opts.Verbose {
 			log.Printf("RecordNumber=%v", r.RecordNumber)
 			log.Printf("TimeGenerated=%v", time.Unix(int64(r.TimeGenerated), 0).String())
 			log.Printf("TimeWritten=%v", time.Unix(int64(r.TimeWritten), 0).String())
-			log.Printf("EventID=%v", r.EventID)
+			log.Printf("EventID=%v", eventID)
 		}
 		lastNumber = r.RecordNumber
 
-		// even code takes last 4 byte
-		eventID := r.EventID & 0x0000FFFF
 		if len(opts.eventIDPattern) > 0 {
 			accepted := false
 			for _, idr := range opts.eventIDPattern {
@@ -482,7 +484,7 @@ loop_events:
 
 			replacer := strings.NewReplacer(
 				"{{source}}", sourceName,
-				"{{id}}", strconv.Itoa(int(r.EventID)),
+				"{{id}}", strconv.Itoa(int(eventID)),
 				"{{message}}", strings.ReplaceAll(message, "\n", ""),
 			)
 


### PR DESCRIPTION
The EVENTLOGRECORD.EventID is a 32-bit value containing Severity, Customer bit, Facility, and Code fields. Only the lower 16 bits (Code) represent the actual Event ID shown in Event Viewer.

The masking (& 0x0000FFFF) was applied for filtering but not for verbose logging or {{id}} output, causing large unexpected numbers to be displayed instead of the expected Event ID.

ref: https://learn.microsoft.com/en-us/windows/win32/eventlog/event-identifiers

---

`1073758208` is `0x40004000` in hex. The lower 16 bits are `0x4000` = `16384`, which is the actual event code.

`--verbose`

before

```
> check-windows-eventlog.exe --log Application --source-pattern "Software Protection Platform Service" --no-state --warning-over 0 --verbose 2>&1 | Select-String -Pattern "EventID=(1073758208|16384)" | Select-Object -First 10
2026/04/15 21:11:49 EventID=1073758208
2026/04/15 21:11:49 EventID=1073758208
2026/04/15 21:11:49 EventID=1073758208
...
```

after
```
> .\check-windows-eventlog.exe --log Application --source-pattern "Software Protection Platform Service" --no-state --warning-over 0 --verbose 2>&1 | Select-String -Pattern "EventID=(1073758208|16384)" | Select-Object -First 10
2026/04/15 21:11:58 EventID=16384
2026/04/15 21:11:58 EventID=16384
2026/04/15 21:11:58 EventID=16384
...
```

`--return`

```
> check-windows-eventlog.exe --log Application --source-pattern "Software Protection Platform Service" --no-state --event-id-pattern=16384 --warning-over 0 --return="Source: {{source}}, ID: {{id}}" 2>&1 | Select-Object -First 10
Event Log WARNING: 392 warnings, 0 criticals.
Source: Software Protection Platform Service, ID: 1073758208
Source: Software Protection Platform Service, ID: 1073758208
Source: Software Protection Platform Service, ID: 1073758208
...
```

after

```
> .\check-windows-eventlog.exe --log Application --source-pattern "Software Protection Platform Service" --no-state --event-id-pattern=16384 --warning-over 0 --return="Source: {{source}}, ID: {{id}}" 2>&1 | Select-Object -First 10
Event Log WARNING: 392 warnings, 0 criticals.
Source: Software Protection Platform Service, ID: 16384
Source: Software Protection Platform Service, ID: 16384
Source: Software Protection Platform Service, ID: 16384
...
```